### PR TITLE
chore: add persistent volume option to auto deploy apps

### DIFF
--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-deployments.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-deployments.yaml
@@ -48,10 +48,19 @@ spec:
           - name: cloudharness-allvalues
             mountPath: /opt/cloudharness/resources/allvalues.yaml
             subPath: allvalues.yaml
+          {{- if .app.harness.deployment.volume }}
+          - name: {{ .app.harness.deployment.volume.name }}
+            mountPath: {{ .app.harness.deployment.volume.mountpath }}
+          {{- end }}
       volumes:
         - name: cloudharness-allvalues
           configMap:
             name: cloudharness-allvalues
+        {{- if .app.harness.deployment.volume }}
+        - name: {{ .app.harness.deployment.volume.name }}
+          persistentVolumeClaim:
+            claimName: {{ .app.harness.deployment.volume.name }}
+        {{- end }}
         
 ---
 {{- end }}

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-volumes.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-volumes.yaml
@@ -1,0 +1,21 @@
+{{- define "deploy_utils.pvolume" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .app.harness.deployment.volume.name }}
+  labels:
+    app: {{ .app.harness.deployment.name| quote }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .app.harness.deployment.volume.size }}
+---
+{{- end }}
+{{- range $app := .Values.apps }}
+    {{- if and $app.harness.deployment.auto $app.harness.deployment.volume }}
+---
+    {{- include "deploy_utils.pvolume" (dict "root" $ "app" $app) }}
+    {{- end }}
+{{- end }}


### PR DESCRIPTION
option for adding a persistent volume to an app

this is how it can be configured:
```
  deployment:
    auto: true
    port: 8080
    volume:
      name: workspaces-images
      size: 4G
      mountpath: /usr/src/app/workspaces/static/workspaces
```