### PR TITLE
#109 codefresh dev and production deployment generation implemented

### DIFF
--- a/utilities/cloudharness_utilities/codefresh.py
+++ b/utilities/cloudharness_utilities/codefresh.py
@@ -2,9 +2,9 @@ import os
 import oyaml as yaml
 import logging
 
-from .constants import HERE, BUILD_STEP_BASE, BUILD_STEP_STATIC, BUILD_STEP_PARALLEL, BUILD_STEP_INSTALL, \
-    CODEFRESH_PATH, CODEFRESH_BUILD_PATH, \
-    CODEFRESH_TEMPLATE_PATH, APPS_PATH, STATIC_IMAGES_PATH, BASE_IMAGES_PATH, DEPLOYMENT_PATH
+from .constants import HERE, CF_BUILD_STEP_BASE, CF_BUILD_STEP_STATIC, CF_BUILD_STEP_PARALLEL, CF_STEP_PUBLISH, \
+    CODEFRESH_PATH, CF_BUILD_PATH, CF_TEMPLATE_PUBLISH_PATH, \
+    CF_TEMPLATE_PATH, APPS_PATH, STATIC_IMAGES_PATH, BASE_IMAGES_PATH, DEPLOYMENT_PATH
 from .helm import collect_helm_values
 from .utils import find_dockerfiles_paths, app_name_from_path, \
     get_image_name, get_template, merge_to_yaml_file, dict_merge
@@ -14,7 +14,8 @@ logging.getLogger().setLevel(logging.INFO)
 CLOUD_HARNESS_PATH = "cloud-harness"
 
 
-def create_codefresh_deployment_scripts(root_paths, codefresh_path=CODEFRESH_PATH, include=()):
+def create_codefresh_deployment_scripts(root_paths, out_filename=CODEFRESH_PATH, include=(),
+                                        template_name=CF_TEMPLATE_PATH):
     """
     Entry point to create deployment scripts for codefresh: codefresh.yaml and helm chart
     """
@@ -22,19 +23,28 @@ def create_codefresh_deployment_scripts(root_paths, codefresh_path=CODEFRESH_PAT
     if include:
         logging.info('Including the following subpaths to the build: %s.', ', '.join(include))
 
-    codefresh = get_template(os.path.join(HERE, CODEFRESH_TEMPLATE_PATH))
+    try:
+        codefresh = get_template(os.path.join(HERE, template_name))
+    except FileNotFoundError as e:
+        if template_name != CF_TEMPLATE_PATH:
+            logging.warning("Template file %s not found", template_name)
+        return
 
-    codefresh['steps'][BUILD_STEP_BASE]['steps'] = {}
-    codefresh['steps'][BUILD_STEP_STATIC]['steps'] = {}
-    codefresh['steps'][BUILD_STEP_PARALLEL]['steps'] = {}
+    if CF_BUILD_STEP_BASE in codefresh['steps']:
+        codefresh['steps'][CF_BUILD_STEP_BASE]['steps'] = {}
+        codefresh['steps'][CF_BUILD_STEP_STATIC]['steps'] = {}
+        codefresh['steps'][CF_BUILD_STEP_PARALLEL]['steps'] = {}
+    if CF_STEP_PUBLISH in codefresh['steps']:
+        codefresh['steps'][CF_STEP_PUBLISH]['steps'] = {}
 
     for root_path in root_paths:
-        template_path = os.path.join(root_path, CODEFRESH_TEMPLATE_PATH)
+        template_path = os.path.join(root_path, template_name)
         if os.path.exists(template_path):
             tpl = get_template(template_path)
-            del tpl['steps'][BUILD_STEP_BASE]
-            del tpl['steps'][BUILD_STEP_STATIC]
-            del tpl['steps'][BUILD_STEP_PARALLEL]
+            del tpl['steps'][CF_BUILD_STEP_BASE]
+            del tpl['steps'][CF_BUILD_STEP_STATIC]
+            del tpl['steps'][CF_BUILD_STEP_PARALLEL]
+            del tpl['steps'][CF_STEP_PUBLISH]
             codefresh = dict_merge(codefresh, tpl)
 
         def codefresh_build_step_from_base_path(base_path, build_step, fixed_context=None):
@@ -45,23 +55,28 @@ def create_codefresh_deployment_scripts(root_paths, codefresh_path=CODEFRESH_PAT
                 app_name = app_name_from_path(app_relative_to_base)
                 if include and not any(inc in dockerfile_path for inc in include):
                     continue
-                build = codefresh_app_build_spec(
-                    app_name=app_name,
-                    app_context_path=os.path.relpath(fixed_context, '.') if fixed_context else app_relative_to_root,
-                    dockerfile_path=os.path.join(os.path.relpath(dockerfile_path, fixed_context) if fixed_context else '',
-                                                 "Dockerfile"))
-                codefresh['steps'][build_step]['steps'][app_name] = build
+                if CF_BUILD_STEP_BASE in codefresh['steps']:
+                    build = codefresh_app_build_spec(
+                        app_name=app_name,
+                        app_context_path=os.path.relpath(fixed_context, '.') if fixed_context else app_relative_to_root,
+                        dockerfile_path=os.path.join(
+                            os.path.relpath(dockerfile_path, fixed_context) if fixed_context else '',
+                            "Dockerfile"))
+                    codefresh['steps'][build_step]['steps'][app_name] = build
+                if CF_STEP_PUBLISH in codefresh['steps']:
+                    codefresh['steps'][CF_STEP_PUBLISH]['steps'][app_name] = codefresh_app_publish_spec(
+                        app_name=app_name)
 
-        codefresh_build_step_from_base_path(os.path.join(root_path, BASE_IMAGES_PATH), BUILD_STEP_BASE,
+        codefresh_build_step_from_base_path(os.path.join(root_path, BASE_IMAGES_PATH), CF_BUILD_STEP_BASE,
                                             fixed_context=root_path)
-        codefresh_build_step_from_base_path(os.path.join(root_path, STATIC_IMAGES_PATH), BUILD_STEP_STATIC)
-        codefresh_build_step_from_base_path(os.path.join(root_path, APPS_PATH), BUILD_STEP_PARALLEL)
+        codefresh_build_step_from_base_path(os.path.join(root_path, STATIC_IMAGES_PATH), CF_BUILD_STEP_STATIC)
+        codefresh_build_step_from_base_path(os.path.join(root_path, APPS_PATH), CF_BUILD_STEP_PARALLEL)
 
     codefresh['steps'] = {k: step for k, step in codefresh['steps'].items() if
                           'type' not in step or step['type'] != 'parallel' or (
                               step['steps'] if 'steps' in step else [])}
 
-    codefresh_abs_path = os.path.join(os.getcwd(), DEPLOYMENT_PATH, codefresh_path)
+    codefresh_abs_path = os.path.join(os.getcwd(), DEPLOYMENT_PATH, out_filename)
     codefresh_dir = os.path.dirname(codefresh_abs_path)
     if not os.path.exists(codefresh_dir):
         os.makedirs(codefresh_dir)
@@ -69,24 +84,42 @@ def create_codefresh_deployment_scripts(root_paths, codefresh_path=CODEFRESH_PAT
         yaml.dump(codefresh, f)
 
 
-def codefresh_build_spec(**kwargs):
+def codefresh_template_spec(template_path, **kwargs):
     """
     Create Codefresh build specification
     :return:
     """
 
-    build = get_template(CODEFRESH_BUILD_PATH)
+    build = get_template(template_path)
 
     build.update(kwargs)
     return build
 
 
+def codefresh_app_publish_spec(app_name):
+    title = app_name.capitalize().replace('-', ' ').replace('/', ' ').replace('.', ' ').strip()
+    step_spec = codefresh_template_spec(
+        template_path=CF_TEMPLATE_PUBLISH_PATH,
+        candidate=get_image_name(app_name),
+        title=title,
+    )
+    step_spec['tags'].append(app_specific_tag_variable(app_name))
+    return step_spec
+
+
+def app_specific_tag_variable(app_name):
+    return "${{ %s }}_${{DEPLOYMENT_PUBLISH_TAG}}" % app_name.replace('-', '_').upper()
+
+
 def codefresh_app_build_spec(app_name, app_context_path, dockerfile_path="Dockerfile"):
     logging.info('Generating build script for ' + app_name)
     title = app_name.capitalize().replace('-', ' ').replace('/', ' ').replace('.', ' ').strip()
-    build = codefresh_build_spec(image_name=get_image_name(app_name), title=title,
-                                 working_directory='./' + app_context_path,
-                                 dockerfile=dockerfile_path)
+    build = codefresh_template_spec(
+        template_path=CF_BUILD_PATH,
+        image_name=get_image_name(app_name),
+        title=title,
+        working_directory='./' + app_context_path,
+        dockerfile=dockerfile_path)
 
     specific_build_template_path = os.path.join(app_context_path, 'build.yaml')
     if os.path.exists(specific_build_template_path):

--- a/utilities/cloudharness_utilities/constants.py
+++ b/utilities/cloudharness_utilities/constants.py
@@ -18,20 +18,19 @@ CODEFRESH_PATH = 'codefresh/codefresh.yaml'
 
 DEPLOYMENT_CONFIGURATION_PATH = 'deployment-configuration'
 
-CODEFRESH_BUILD_PATH = f'{DEPLOYMENT_CONFIGURATION_PATH}/codefresh-build-template.yaml'
-CODEFRESH_TEMPLATE_PATH = f'{DEPLOYMENT_CONFIGURATION_PATH}/codefresh-template.yaml'
-CODEFRESH_REGISTRY = "r.cfcr.io/tarelli"
+CF_BUILD_PATH = f'{DEPLOYMENT_CONFIGURATION_PATH}/codefresh-build-template.yaml'
+CF_TEMPLATE_PATH = f'{DEPLOYMENT_CONFIGURATION_PATH}/codefresh-template.yaml'
+CF_TEMPLATE_PUBLISH_PATH = f'{DEPLOYMENT_CONFIGURATION_PATH}/codefresh-publish-template.yaml'
 
 VALUES_MANUAL_PATH = 'values.yaml'
 VALUE_TEMPLATE_PATH = f'{DEPLOYMENT_CONFIGURATION_PATH}/value-template.yaml'
 
-CH_BASE_IMAGES = {'cloudharness-base': 'python:3.7-alpine', 'cloudharness-base-debian': 'python:3'}
+CH_BASE_IMAGES = {'cloudharness-base': 'python:3.7-alpine', 'cloudharness-base-debian': 'python:3.7'}
 
 
-BUILD_STEP_BASE = 'build_base_images'
-BUILD_STEP_STATIC = 'build_static_images'
-BUILD_STEP_PARALLEL = 'build_application_images'
-BUILD_STEP_INSTALL = 'deployment'
-
+CF_BUILD_STEP_BASE = 'build_base_images'
+CF_BUILD_STEP_STATIC = 'build_static_images'
+CF_BUILD_STEP_PARALLEL = 'build_application_images'
+CF_STEP_INSTALL = 'deployment'
+CF_STEP_PUBLISH = 'publish'
 BUILD_FILENAMES = ('node_modules',)
-

--- a/utilities/cloudharness_utilities/deployment-configuration/README.md
+++ b/utilities/cloudharness_utilities/deployment-configuration/README.md
@@ -2,7 +2,11 @@
 Templates used to personalize the automatic infrastructure definition.
 Those files are used by the script `insfrastructure-generate.py`
 
-- `values-template.yaml`: base for `helm/values.yaml`. Modify this file to add values related to new infrastructure elements not defined as a CloudHarness application (e.g. a new database)
-- `value-template.yaml`: base for cloudharness application configuration inside `values.yaml`. Prefer adding a custom `values.yaml` to your application over changing this file.
-- `codefresh-template.yaml`: base for `codefresh/codefresh.yaml`. Modify this file if you want to change the build steps inside codefresh
+- `values-template.yaml`: base for `helm/values.yaml`. Modify this file to add values related to new infrastructure 
+  elements not defined as a CloudHarness application (e.g. a new database)
+- `value-template.yaml`: base for cloudharness application configuration inside `values.yaml`. 
+  Prefer adding a custom `values.yaml` to your application over changing this file.
+- `codefresh-template-[dev|prod].yaml`: base for `codefresh/codefresh-[dev|prod].yaml`. 
+  Modify this file if you want to change the build steps inside codefresh
 - `codefresh-build-template.yaml`: base for a single build entry in `codefresh.yaml`
+- `codefresh-publish-template.yaml`: base for a single publish (image tagging) entry in `codefresh.yaml`

--- a/utilities/cloudharness_utilities/deployment-configuration/codefresh-publish-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/codefresh-publish-template.yaml
@@ -1,0 +1,7 @@
+stage: 'publish'
+type: push
+title: REPLACE_ME
+candidate: REPLACE_ME
+tags:
+  - ${{DEPLOYMENT_PUBLISH_TAG}}
+registry: ${{REGISTRY}}

--- a/utilities/cloudharness_utilities/deployment-configuration/codefresh-template-dev.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/codefresh-template-dev.yaml
@@ -3,6 +3,7 @@ stages:
   - prepare
   - build
   - deploy
+  - publish
 steps:
   main_clone:
     title: Clone main repository
@@ -63,3 +64,8 @@ steps:
       - HELM_REPO_CONTEXT_PATH=
       - TIMEOUT=600
       - VALUESFILE_values=./deployment/helm/values.yaml
+  publish:
+    type: parallel
+    stage: publish
+    steps:
+      REPLACE_ME

--- a/utilities/cloudharness_utilities/deployment-configuration/codefresh-template-prod.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/codefresh-template-prod.yaml
@@ -1,0 +1,53 @@
+version: '1.0'
+stages:
+  - prepare
+  - deploy
+  - publish
+steps:
+  main_clone:
+    title: Clone main repository
+    type: git-clone
+    stage: prepare
+    repo: '${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}'
+    revision: '${{CF_BRANCH}}'
+    git: github
+  post_main_clone:
+    title: Post main clone
+    type: parallel
+    stage: prepare
+  prepare_deployment:
+    title: "Prepare helm chart"
+    image: python:3.7
+    stage: prepare
+    working_directory: .
+    commands:
+      - pip install cloud-harness/utilities
+      - harness-deployment . cloud-harness -m build -t ${{DEPLOYMENT_TAG}} -d ${{DOMAIN}} -r ${{REGISTRY}} -rs ${{REGISTRY_SECRET}}
+  prepare_deployment_view:
+    commands:
+      - 'helm template ./deployment/helm --debug -n ${{NAME}}'
+    environment:
+      - ACTION=auth
+      - KUBE_CONTEXT=${{NAME}}
+    image: codefresh/cfstep-helm:3.0.3
+    stage: prepare
+    title: 'View helm chart'
+  deployment:
+    stage: deploy
+    image: codefresh/cfstep-helm:3.0.3
+    title: Installing chart
+    environment:
+      - CHART_REF=./deployment/helm
+      - RELEASE_NAME=${{NAMESPACE}}
+      - KUBE_CONTEXT=${{CLUSTER_NAME}}
+      - NAMESPACE=${{NAMESPACE}}
+      - CHART_VERSION=0.0.1
+      - HELM_REPO_USE_HTTP=false
+      - HELM_REPO_CONTEXT_PATH=
+      - TIMEOUT=600
+      - VALUESFILE_values=./deployment/helm/values.yaml
+  publish:
+    type: parallel
+    stage: publish
+    steps:
+      REPLACE_ME

--- a/utilities/cloudharness_utilities/utils.py
+++ b/utilities/cloudharness_utilities/utils.py
@@ -28,11 +28,7 @@ def get_parent_app_name(app_relative_path):
 
 
 def get_image_name(app_name, base_name=None):
-    return base_name + '-' + app_name if base_name else app_name
-
-
-def get_image_name_from_dockerfile_path(self, dockerfile_path, base_name):
-    return get_image_name(os.path.basename(os.path.dirname(dockerfile_path)), base_name)
+    return base_name + '/' + app_name if base_name else app_name
 
 
 def env_variable(name, value):

--- a/utilities/harness-deployment
+++ b/utilities/harness-deployment
@@ -87,5 +87,8 @@ if __name__ == "__main__":
             registry_secret=args.registry_secret,
             tls=not args.no_tls
         )
-        create_codefresh_deployment_scripts(builder.root_paths, include=args.include)
+        create_codefresh_deployment_scripts(builder.root_paths, include=args.include) # LEGACY
+        create_codefresh_deployment_scripts(builder.root_paths, include=args.include, template_name='codefresh-template-dev.yaml', out_filename="codefresh-dev.yaml")
+        create_codefresh_deployment_scripts(builder.root_paths, include=args.include,
+                                            template_name='codefresh-template-prod.yaml', out_filename="codefresh-prod.yaml")
         hosts_info(values_manual_deploy)


### PR DESCRIPTION
Closes #109 

After this pr, the codefresh pipeline must be changed to point to either 
- deployment/codefresh-dev.yaml
- deployment/codefresh-prod.yaml

Also check your application deployment-configuration: codefresh-template.yaml splits into 

- codefresh-template-dev.yaml
- codefresh-template-prod.yaml

The content must be adapted from the content inside codefresh-template-dev.yaml and the current codefresh-template.yaml
