### PR TITLE
Feature/135: Centralize database management phase 1

### DIFF
--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
@@ -9,13 +9,7 @@
         - name: POSTGRES_PASSWORD
           value: {{ .app.harness.database.pass | quote }}
         - name: PGDATA
-          value: {{ .app.harness.database.postgres.pgdata }}
-        ports:
-        - name: http
-          containerPort: {{ .app.harness.database.port }}
-        volumeMounts:
-          - name: {{ .app.harness.database.name | quote }}
-            mountPath: {{ .app.harness.database.postgres.datavolume }}
+          value: pgdata
 {{- end }}
 {{- define "deploy_utils.database.mongo" }}
         image: {{ .app.harness.database.mongo.image }}
@@ -24,9 +18,6 @@
             value: {{ .app.harness.database.user | quote }}
           - name: MONGO_INITDB_ROOT_PASSWORD
             value: {{ .app.harness.database.pass | quote }}
-        ports:
-        - name: http
-          containerPort: {{ .app.harness.database.port }}
         livenessProbe:
           exec:
             command:
@@ -45,9 +36,6 @@
           initialDelaySeconds: 5
           timeoutSeconds: 5
           failureThreshold: 6
-        volumeMounts:
-          - name: {{ .app.harness.database.name | quote }}
-            mountPath: /data/db
 {{- end }}
 {{- define "deploy_utils.database" }}
 ---
@@ -81,12 +69,12 @@ spec:
       containers:
       - name: {{ .app.harness.database.name | quote }}
         imagePullPolicy: IfNotPresent
-{{- if eq .app.harness.database.type "mongo" }}
-  {{ include "deploy_utils.database.mongo" (dict "root" .root "app" .app) }}
-{{- end }}
-{{- if eq .app.harness.database.type "postgres" }}
-  {{ include "deploy_utils.database.postgres" (dict "root" .root "app" .app) }}
-{{- end }}
+        {{ include (print "deploy_utils.database." .app.harness.database.type) (dict "root" .root "app" .app) }}
+        ports:
+        {{- range $port := (index .app.harness.database .app.harness.database.type).ports }}
+        - name: {{ $port.name }}
+          containerPort: {{ $port.port }}
+        {{- end }}
         resources:
           requests:
             memory: {{ .app.harness.database.resources.requests.memory | default "32Mi" }}
@@ -94,6 +82,9 @@ spec:
           limits:
             memory: {{ .app.harness.database.resources.limits.memory | default "64Mi" }}
             cpu: {{ .app.harness.database.resources.limits.cpu | default "50m" }}
+        volumeMounts:
+          - name: {{ .app.harness.database.name | quote }}
+            mountPath: /data/db
       volumes:
       - name: {{ .app.harness.database.name | quote }}
         persistentVolumeClaim:
@@ -112,7 +103,10 @@ spec:
   selector:
     app: {{ .app.harness.database.name| quote }}
   ports:
-  - port: {{ .app.harness.database.port }}
+  {{- range $port := (index .app.harness.database .app.harness.database.type).ports }}
+  - name: {{ $port.name }}
+    port: {{ $port.port }}
+  {{- end }}
 ---
 {{- end }}
 {{- range $app := .Values.apps }}

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
@@ -1,4 +1,22 @@
 {{/* Services */}}
+{{- define "deploy_utils.database.postgres" }}
+        image: postgres:latest
+        env:
+        - name: POSTGRES_DB
+          value: {{ .app.harness.database.postgres.initialdb | quote }}
+        - name: POSTGRES_USER
+          value: {{ .app.harness.database.user | quote }}
+        - name: POSTGRES_PASSWORD
+          value: {{ .app.harness.database.pass | quote }}
+        - name: PGDATA
+          value: {{ .app.harness.database.postgres.pgdata }}
+        ports:
+        - name: http
+          containerPort: {{ .app.harness.database.port }}
+        volumeMounts:
+          - name: {{ .app.harness.database.name | quote }}
+            mountPath: {{ .app.harness.database.postgres.datavolume }}
+{{- end }}
 {{- define "deploy_utils.database.mongodb" }}
         image: mongo:latest
         env:
@@ -65,6 +83,9 @@ spec:
         imagePullPolicy: IfNotPresent
 {{- if eq .app.harness.database.type "mongodb" }}
   {{ include "deploy_utils.database.mongodb" (dict "root" .root "app" .app) }}
+{{- end }}
+{{- if eq .app.harness.database.type "postgres" }}
+  {{ include "deploy_utils.database.postgres" (dict "root" .root "app" .app) }}
 {{- end }}
         resources:
           requests:

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
@@ -9,7 +9,7 @@
         - name: POSTGRES_PASSWORD
           value: {{ .app.harness.database.pass | quote }}
         - name: PGDATA
-          value: pgdata
+          value: /data/db/pgdata
 {{- end }}
 {{- define "deploy_utils.database.mongo" }}
         image: {{ .app.harness.database.mongo.image }}
@@ -36,6 +36,26 @@
           initialDelaySeconds: 5
           timeoutSeconds: 5
           failureThreshold: 6
+{{- end }}
+{{- define "deploy_utils.database.neo4j" }}
+        image: {{ .app.harness.database.neo4j.image }}
+        env:
+          - name: NEO4J_dbms_directories_data
+            value: /data/db/data
+          - name: NEO4J_dbms_directories_logs
+            value: /data/db/logs
+          - name: NEO4J_dbms_directories_metrics
+            value: /data/db/metrics
+          - name: NEO4J_dbms_memory_size
+            value: {{ .app.harness.database.neo4j.memory.size }}
+          - name: NEO4J_dbms_memory_pagecache_size
+            value: {{ .app.harness.database.neo4j.memory.pagecache.size }}
+          - name: NEO4J_dbms_memory_heap_initial__size
+            value: {{ .app.harness.database.neo4j.memory.heap.initial }}
+          - name: NEO4J_dbms_memory_heap_max__size
+            value: {{ .app.harness.database.neo4j.memory.heap.max }}
+          - name: NEO4J_dbms_security_auth__enabled
+            value: {{ .app.harness.database.neo4j.dbms_security_auth_enabled | quote }}
 {{- end }}
 {{- define "deploy_utils.database" }}
 ---

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
@@ -1,0 +1,110 @@
+{{/* Services */}}
+{{- define "deploy_utils.database.mongodb" }}
+        image: mongo:latest
+        env:
+          - name: MONGO_INITDB_ROOT_USERNAME
+            value: {{ .app.harness.database.user | quote }}
+          - name: MONGO_INITDB_ROOT_PASSWORD
+            value: {{ .app.harness.database.pass | quote }}
+        ports:
+        - name: http
+          containerPort: {{ .app.harness.database.port }}
+        livenessProbe:
+          exec:
+            command:
+            - mongo
+            - --eval
+            - "db.adminCommand('ping')"
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 6
+        readinessProbe:
+          exec:
+            command:
+            - mongo
+            - --eval
+            - "db.adminCommand('ping')"
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 6
+        volumeMounts:
+          - name: {{ .app.harness.database.name | quote }}
+            mountPath: /data/db
+{{- end }}
+{{- define "deploy_utils.database" }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .app.harness.database.name | quote }}
+  namespace: {{ .root.Values.namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .app.harness.database.size }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .app.harness.database.name | quote }}
+  namespace: {{ .root.Values.namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .app.harness.database.name | quote }}
+  template:
+    metadata:
+      labels:
+        app: {{ .app.harness.database.name | quote }}
+    spec:
+      containers:
+      - name: {{ .app.harness.database.name | quote }}
+        imagePullPolicy: IfNotPresent
+{{- if eq .app.harness.database.type "mongodb" }}
+  {{ include "deploy_utils.database.mongodb" (dict "root" .root "app" .app) }}
+{{- end }}
+        resources:
+          requests:
+            memory: {{ .app.harness.database.resources.requests.memory | default "32Mi" }}
+            cpu: {{ .app.harness.database.resources.requests.cpu | default "25m" }}
+          limits:
+            memory: {{ .app.harness.database.resources.limits.memory | default "64Mi" }}
+            cpu: {{ .app.harness.database.resources.limits.cpu | default "50m" }}
+      volumes:
+      - name: {{ .app.harness.database.name | quote }}
+        persistentVolumeClaim:
+          claimName: {{ .app.harness.database.name | quote }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .app.harness.database.name | quote }}
+  namespace: {{ .root.Values.namespace }}
+  labels:
+    app: {{ .app.harness.deployment.name | quote }}
+{{ include "deploy_utils.labels" .root | indent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ .app.harness.database.name| quote }}
+  ports:
+  - port: {{ .app.harness.database.port }}
+---
+{{- end }}
+{{- range $app := .Values.apps }}
+  {{- if $app.harness.database.auto  }}
+     {{ include "deploy_utils.database" (dict "root" $ "app" $app) }}
+  {{- end }}
+  {{- range $subapp := $app }}
+  {{- if contains "map" (typeOf $subapp)  }}
+  {{- if hasKey $subapp "harness"}}
+  {{- if and (hasKey $subapp.harness "database") $subapp.harness.database.auto }}
+      {{ include "deploy_utils.database" (dict "root" $ "app" $subapp) }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
@@ -1,6 +1,6 @@
 {{/* Services */}}
 {{- define "deploy_utils.database.postgres" }}
-        image: postgres:latest
+        image: {{ .app.harness.database.postgres.image }}
         env:
         - name: POSTGRES_DB
           value: {{ .app.harness.database.postgres.initialdb | quote }}
@@ -17,8 +17,8 @@
           - name: {{ .app.harness.database.name | quote }}
             mountPath: {{ .app.harness.database.postgres.datavolume }}
 {{- end }}
-{{- define "deploy_utils.database.mongodb" }}
-        image: mongo:latest
+{{- define "deploy_utils.database.mongo" }}
+        image: {{ .app.harness.database.mongo.image }}
         env:
           - name: MONGO_INITDB_ROOT_USERNAME
             value: {{ .app.harness.database.user | quote }}
@@ -81,8 +81,8 @@ spec:
       containers:
       - name: {{ .app.harness.database.name | quote }}
         imagePullPolicy: IfNotPresent
-{{- if eq .app.harness.database.type "mongodb" }}
-  {{ include "deploy_utils.database.mongodb" (dict "root" .root "app" .app) }}
+{{- if eq .app.harness.database.type "mongo" }}
+  {{ include "deploy_utils.database.mongo" (dict "root" .root "app" .app) }}
 {{- end }}
 {{- if eq .app.harness.database.type "postgres" }}
   {{ include "deploy_utils.database.postgres" (dict "root" .root "app" .app) }}

--- a/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
@@ -28,7 +28,7 @@ harness:
     auto: false
     name:
     type:
-    # supported db types: mongo, postgres
+    # supported db types: mongo, postgres, neo4j
     size: 1Gi
     user: mnp
     pass: metacell

--- a/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
@@ -24,3 +24,18 @@ harness:
     auto: true
     name:
     port: 80
+  database:
+    auto: false
+    name:
+    type:
+    size: 1Gi
+    user: mnp
+    pass: metacell
+    port: 27017
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "500Mi"
+        cpu: "500m"

--- a/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
@@ -32,14 +32,17 @@ harness:
     size: 1Gi
     user: mnp
     pass: metacell
-    port: 27017
-    mongodb:
+    mongo:
       image: mongo:latest
+      ports:
+        - name: http
+          port: 27017
     postgres:
       image: postgres:latest
       initialdb: cloudharness
-      datavolume: /opt/data/
-      pgdata: /opt/data/pgdata
+      ports:
+        - name: http
+          port: 5432
     resources:
       requests:
         memory: "64Mi"

--- a/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
@@ -28,11 +28,15 @@ harness:
     auto: false
     name:
     type:
+    # supported db types: mongo, postgres
     size: 1Gi
     user: mnp
     pass: metacell
     port: 27017
+    mongodb:
+      image: mongo:latest
     postgres:
+      image: postgres:latest
       initialdb: cloudharness
       datavolume: /opt/data/
       pgdata: /opt/data/pgdata

--- a/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
@@ -43,10 +43,25 @@ harness:
       ports:
         - name: http
           port: 5432
+    neo4j:
+      image: neo4j:latest
+      memory:
+        size: 256M
+        pagecache:
+          size: 64M
+        heap:
+          initial: 64M
+          max: 128M
+      dbms_security_auth_enabled: "false"
+      ports:
+        - name: http
+          port: 7474
+        - name: bolt
+          port: 7687
     resources:
       requests:
-        memory: "64Mi"
-        cpu: "50m"
+        memory: "512Mi"
+        cpu: "200m"
       limits:
-        memory: "500Mi"
-        cpu: "500m"
+        memory: "2Gi"
+        cpu: "1000m"

--- a/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
@@ -32,6 +32,10 @@ harness:
     user: mnp
     pass: metacell
     port: 27017
+    postgres:
+      initialdb: cloudharness
+      datavolume: /opt/data/
+      pgdata: /opt/data/pgdata
     resources:
       requests:
         memory: "64Mi"

--- a/utilities/cloudharness_utilities/helm.py
+++ b/utilities/cloudharness_utilities/helm.py
@@ -17,6 +17,7 @@ from .utils import get_cluster_ip, get_image_name, env_variable, get_sub_paths, 
 
 KEY_HARNESS = 'harness'
 KEY_SERVICE = 'service'
+KEY_DATABASE = 'database'
 KEY_DEPLOYMENT = 'deployment'
 KEY_APPS = 'apps'
 
@@ -220,6 +221,8 @@ def create_values_spec(app_name, app_path, tag=None, registry='', template_path=
         harness[KEY_SERVICE]['name'] = app_name
     if not harness[KEY_DEPLOYMENT]['name']:
         harness[KEY_DEPLOYMENT]['name'] = app_name
+    if not harness[KEY_DATABASE]['name']:
+        harness[KEY_DATABASE]['name'] = app_name.strip() + '-db'
     if not harness[KEY_DEPLOYMENT]['image']:
         if registry and registry[-1] != '/':
             registry = registry + '/'


### PR DESCRIPTION
First phase of centralizing database management
implements: mongo, postgres and neo4j database pod/service creation
add new default settings in value-template.yaml for use in app values.yaml:
```
database:
    auto: false
    name:
    type:
    # supported db types: mongo, postgres, neo4j
    size: 1Gi
    user: mnp
    pass: metacell
    mongo:
      image: mongo:latest
      ports:
        - name: http
          port: 27017
    postgres:
      image: postgres:latest
      initialdb: cloudharness
      ports:
        - name: http
          port: 5432
    neo4j:
      image: neo4j:latest
      memory:
        size: 256M
        pagecache:
          size: 64M
        heap:
          initial: 64M
          max: 128M
      dbms_security_auth_enabled: "false"
      ports:
        - name: http
          port: 7474
        - name: bolt
          port: 7687
    resources:
      requests:
        memory: "512Mi"
        cpu: "200m"
      limits:
        memory: "2Gi"
        cpu: "1000m"
```