### PR TITLE
#159 fix main ingress assignment

### DIFF
--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/ingress.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/ingress.yaml
@@ -20,6 +20,7 @@
 {{- if .Values.ingress.enabled }}
 {{ $domain := .Values.domain }}
 {{ $tls := not (not .Values.tls) }}
+{{ $mainapp := .Values.mainapp }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -37,10 +38,15 @@ metadata:
 spec:
   rules:
   {{- range $app := .Values.apps }}
-    {{- if $app.harness.domain }}
+    {{- if (eq $app.harness.name $mainapp) }}
   - host: {{ $domain | quote }}
     {{ include "deploy_utils.ingress.http" (dict "root" $ "app" $app) }}
-    {{- else if $app.harness.subdomain }}
+    {{- end }}
+    {{- if $app.harness.domain }}
+  - host: {{ $app.harness.domain | quote }}
+    {{ include "deploy_utils.ingress.http" (dict "root" $ "app" $app) }}
+    {{- end }}
+    {{- if $app.harness.subdomain }}
   - host: {{ printf "%s.%s" $app.harness.subdomain $domain | quote }}
     {{ include "deploy_utils.ingress.http" (dict "root" $ "app" $app) }}
     {{- range $service := $app.harness.use_services }}
@@ -62,10 +68,14 @@ spec:
       {{- range $app := .Values.apps }}
           {{- if $app.harness.subdomain }}
       - {{ printf "%s.%s" $app.harness.subdomain $domain | quote }}
-          {{- else if $app.domain }}
-      - {{ $domain | quote }}
+          {{- end }}
+          {{- if (and $app.harness.domain (ne $app.harness.domain $domain)) }}
+      - {{ $app.harness.domain | quote }}
           {{- end }}
       {{- end }}
-    secretName: {{ $tls | quote }}
+      {{- if $mainapp }}
+      - {{ $domain | quote }}
+      {{- end }}
+    secretName: tls-secret
   {{- end }}
 {{- end }}

--- a/utilities/cloudharness_utilities/deployment-configuration/values-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/values-template.yaml
@@ -4,6 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 domain: ${{DOMAIN}}
 namespace: ch
+mainapp: samples
 registry:
   name: "localhost:5000"
   secret:

--- a/utilities/cloudharness_utilities/deployment-configuration/values-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/values-template.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 domain: ${{DOMAIN}}
 namespace: ch
-mainapp: samples
+mainapp: accounts
 registry:
   name: "localhost:5000"
   secret:

--- a/utilities/cloudharness_utilities/helm.py
+++ b/utilities/cloudharness_utilities/helm.py
@@ -287,17 +287,17 @@ def hosts_info(values):
         logging.warning('Cannot get cluster ip')
         return
     logging.info(
-        "\nTo test locally, update your hosts file" + f"\n{ip}\t{' '.join(sd + '.' + domain for sd in subdomains)}")
+        "\nTo test locally, update your hosts file" + f"\n{ip}\t{domain + ' ' + ' '.join(sd + '.' + domain for sd in subdomains)}")
 
     deployments = (app[KEY_HARNESS][KEY_DEPLOYMENT]['name'] for app in values[KEY_APPS].values() if KEY_HARNESS in app)
 
     logging.info("\nTo run locally some apps, also those references may be needed")
     for appname in values[KEY_APPS]:
-        app = values[KEY_APPS][appname]
-        if 'name' not in app or 'port' not in app: continue
+        app = values[KEY_APPS][appname]['harness']
+        if 'deployment' not in app: continue
         print(
             "kubectl port-forward -n {namespace} deployment/{app} {port}:{port}".format(
-                app=appname, port=app['port'], namespace=namespace))
+                app=app['deployment']['name'], port=app['deployment']['port'], namespace=namespace))
 
     print(f"127.0.0.1\t{' '.join(s + '.cloudharness' for s in deployments)}")
 


### PR DESCRIPTION
Closes #159.

To configure the main address in the application now edit `mainapp` value in `values-template.yaml`.

For instance the values .yaml
```yaml
mainapp: myapp
domain: cloudharness.org
apps:
   myapp:
      harness:
         name: myapp
         subdomain: my
         domain: www.myapp.org
```

Will set "myapp" ingress to the following domains:
* cloudharness.org
* my.cloudharness.org
* www.myapp.org
