### PR TITLE
Feature/157 postgres and mongo backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,15 @@ or simply copy the *blueprint* folder
 The Kubernetes client `kubectl` must be set up and working on the local machine,
 for instance with a Google Cloud cluster or a local Minikube.
 
-1. Locally build the images with `harness-deployment -b -l
+1. Locally build the images with `harness-deployment . -b -l
 [--registry localhost:5000] [--tag 0.0.1]`
 1. Create the namespace `kubectl create ns ch`
 1. Create the namespace `kubectl create ns argo-workflows`
-1. (Optional) Try the helm chart with `helm install helm --name ch --namespace ch --dry-run`
+1. (Optional) Try the helm chart with `helm install ch deployment/helm -n ch --dry-run`
 1. Install or upgrade the helm chart with `helm install ch deployment/helm  -n ch --dependency-update` on helm 3)
 
 To upgrade an already existing chart, run
-`helm upgrade ch deployment/helm -n ch --install --reset-values `
+`helm upgrade ch deployment/helm -n ch --install --reset-values`
 
 ### Continuous deployment with Codefresh
 The codefresh pipeline setup is provided in `codefresh/codefresh.yaml`.
@@ -209,7 +209,7 @@ outside Codefresh, for instance for local testing with Minikube.
 
 #### How to build
 
-Run `harness-deployment -b -l` (all images are built unless `-i` option is provided).
+Run `harness-deployment . -b -l` (all images are built unless `-i` option is provided).
 
 For further information, run `harness-deployment --help`
 

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/files/db-mongo-backup.sh
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/files/db-mongo-backup.sh
@@ -1,0 +1,36 @@
+/bin/bash << 'EOF'
+KEEP_DAYS=${BACKUP_KEEP_DAYS}
+KEEP_WEEKS=`expr $(((${BACKUP_KEEP_WEEKS} * 7) + 1))`
+KEEP_MONTHS=`expr $(((${BACKUP_KEEP_MONTHS} * 31) + 1))`
+
+mkdir -p "${BACKUP_DIR}/daily/" "${BACKUP_DIR}/weekly/" "${BACKUP_DIR}/monthly/"
+DFILE="${BACKUP_DIR}/daily/`date +%Y-%m-%d-%H%M%S`${BACKUP_SUFFIX}"
+WFILE="${BACKUP_DIR}/weekly/`date +%G-%V`${BACKUP_SUFFIX}"
+MFILE="${BACKUP_DIR}/monthly/`date +%Y-%m`${BACKUP_SUFFIX}"
+
+# Dump mongo database
+/usr/bin/mongodump -h $DB_HOST -u $DB_USER -p $DB_PASS --archive=$DFILE --gzip
+ls backups/*
+
+# Use hardlink instead of copy to save space
+if [ -d "${DFILE}" ]; then
+    WFILENEW="${WFILE}-new"
+    MFILENEW="${MFILE}-new"
+    rm -rf "${WFILENEW}" "${MFILENEW}"
+    mkdir "${WFILENEW}" "${MFILENEW}"
+    ln -f "${DFILE}/"* "${WFILENEW}/"
+    ln -f "${DFILE}/"* "${MFILENEW}/"
+    rm -rf "${WFILE}" "${MFILE}"
+    mv -v "${WFILENEW}" "${WFILE}"
+    mv -v "${MFILENEW}" "${MFILE}"
+else
+    ln -vf "${DFILE}" "${WFILE}"
+    ln -vf "${DFILE}" "${MFILE}"
+fi
+
+# Clean old files
+echo "Cleaning backups older than ${KEEP_DAYS} ..."
+find "${BACKUP_DIR}/daily" -maxdepth 1 -mtime +${KEEP_DAYS} -name "*${BACKUP_SUFFIX}" -print -delete
+find "${BACKUP_DIR}/weekly" -maxdepth 1 -mtime +${KEEP_WEEKS} -name "*${BACKUP_SUFFIX}" -print -delete
+find "${BACKUP_DIR}/monthly" -maxdepth 1 -mtime +${KEEP_MONTHS} -name "*${BACKUP_SUFFIX}" -print -delete
+EOF

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/files/db-mongo-backup.sh
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/files/db-mongo-backup.sh
@@ -1,9 +1,20 @@
-/bin/bash << 'EOF'
+#!/bin/bash
+
+set -e
+set -u
+
 KEEP_DAYS=${BACKUP_KEEP_DAYS}
 KEEP_WEEKS=`expr $(((${BACKUP_KEEP_WEEKS} * 7) + 1))`
 KEEP_MONTHS=`expr $(((${BACKUP_KEEP_MONTHS} * 31) + 1))`
 
 mkdir -p "${BACKUP_DIR}/daily/" "${BACKUP_DIR}/weekly/" "${BACKUP_DIR}/monthly/"
+
+# Clean old files
+echo "Cleaning backups older than ${KEEP_DAYS} ..."
+find "${BACKUP_DIR}/daily" -maxdepth 1 -mtime +${KEEP_DAYS} -name "*${BACKUP_SUFFIX}" -print -delete
+find "${BACKUP_DIR}/weekly" -maxdepth 1 -mtime +${KEEP_WEEKS} -name "*${BACKUP_SUFFIX}" -print -delete
+find "${BACKUP_DIR}/monthly" -maxdepth 1 -mtime +${KEEP_MONTHS} -name "*${BACKUP_SUFFIX}" -print -delete
+
 DFILE="${BACKUP_DIR}/daily/`date +%Y-%m-%d-%H%M%S`${BACKUP_SUFFIX}"
 WFILE="${BACKUP_DIR}/weekly/`date +%G-%V`${BACKUP_SUFFIX}"
 MFILE="${BACKUP_DIR}/monthly/`date +%Y-%m`${BACKUP_SUFFIX}"
@@ -26,10 +37,3 @@ else
     ln -vf "${DFILE}" "${WFILE}"
     ln -vf "${DFILE}" "${MFILE}"
 fi
-
-# Clean old files
-echo "Cleaning backups older than ${KEEP_DAYS} ..."
-find "${BACKUP_DIR}/daily" -maxdepth 1 -mtime +${KEEP_DAYS} -name "*${BACKUP_SUFFIX}" -print -delete
-find "${BACKUP_DIR}/weekly" -maxdepth 1 -mtime +${KEEP_WEEKS} -name "*${BACKUP_SUFFIX}" -print -delete
-find "${BACKUP_DIR}/monthly" -maxdepth 1 -mtime +${KEEP_MONTHS} -name "*${BACKUP_SUFFIX}" -print -delete
-EOF

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/files/db-mongo-backup.sh
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/files/db-mongo-backup.sh
@@ -10,7 +10,6 @@ MFILE="${BACKUP_DIR}/monthly/`date +%Y-%m`${BACKUP_SUFFIX}"
 
 # Dump mongo database
 /usr/bin/mongodump -h $DB_HOST -u $DB_USER -p $DB_PASS --archive=$DFILE --gzip
-ls backups/*
 
 # Use hardlink instead of copy to save space
 if [ -d "${DFILE}" ]; then

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-mongo-backup.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-mongo-backup.yaml
@@ -10,7 +10,7 @@ spec:
       template:
         spec:
           containers:
-            - name: mongodb-backup
+            - name: "{{ .app.harness.database.name }}-backup"
               image: {{ .app.harness.database.mongo.image }}
               imagePullPolicy: IfNotPresent
               command: ["/bin/sh"]
@@ -18,20 +18,40 @@ spec:
                 - -c
                 - |
                   /bin/bash << 'EOF'
-                  # Create new backup
-                  echo Started backup
-                  FILE=/backups/$(date "+%Y-%m-%d-%H-%M").gz
-                  /usr/bin/mongodump -h $DB_HOST -u $DB_USER -p $DB_PASS --archive=$FILE --gzip
-                  echo Added new backup $FILE
+                  KEEP_DAYS=${BACKUP_KEEP_DAYS}
+                  KEEP_WEEKS=`expr $(((${BACKUP_KEEP_WEEKS} * 7) + 1))`
+                  KEEP_MONTHS=`expr $(((${BACKUP_KEEP_MONTHS} * 31) + 1))`
 
-                  # Cleanup procedure
-                  EXISTING=$(find backups/*.gz | wc -l)
-                  echo Found $EXISTING backups
-                  if [ $EXISTING -gt $KEEP_DAYS ]; then
-                      echo Start cleaing ...
-                      find backups/* -mtime +$KEEP_DAYS -delete -print
-                      echo Finished cleaning
+                  mkdir -p "${BACKUP_DIR}/daily/" "${BACKUP_DIR}/weekly/" "${BACKUP_DIR}/monthly/"
+                  DFILE="${BACKUP_DIR}/daily/`date +%Y-%m-%d-%H%M%S`${BACKUP_SUFFIX}"
+                  WFILE="${BACKUP_DIR}/weekly/`date +%G-%V`${BACKUP_SUFFIX}"
+                  MFILE="${BACKUP_DIR}/monthly/`date +%Y-%m`${BACKUP_SUFFIX}"
+
+                  # Dump mongo database
+                  /usr/bin/mongodump -h $DB_HOST -u $DB_USER -p $DB_PASS --archive=$DFILE --gzip
+                  ls backups/*
+
+                  # Use hardlink instead of copy to save space
+                  if [ -d "${DFILE}" ]; then
+                      WFILENEW="${WFILE}-new"
+                      MFILENEW="${MFILE}-new"
+                      rm -rf "${WFILENEW}" "${MFILENEW}"
+                      mkdir "${WFILENEW}" "${MFILENEW}"
+                      ln -f "${DFILE}/"* "${WFILENEW}/"
+                      ln -f "${DFILE}/"* "${MFILENEW}/"
+                      rm -rf "${WFILE}" "${MFILE}"
+                      mv -v "${WFILENEW}" "${WFILE}"
+                      mv -v "${MFILENEW}" "${MFILE}"
+                  else
+                      ln -vf "${DFILE}" "${WFILE}"
+                      ln -vf "${DFILE}" "${MFILE}"
                   fi
+
+                  # Clean old files
+                  echo "Cleaning backups older than ${KEEP_DAYS} ..."
+                  find "${BACKUP_DIR}/daily" -maxdepth 1 -mtime +${KEEP_DAYS} -name "*${BACKUP_SUFFIX}" -print -delete
+                  find "${BACKUP_DIR}/weekly" -maxdepth 1 -mtime +${KEEP_WEEKS} -name "*${BACKUP_SUFFIX}" -print -delete
+                  find "${BACKUP_DIR}/monthly" -maxdepth 1 -mtime +${KEEP_MONTHS} -name "*${BACKUP_SUFFIX}" -print -delete
                   EOF
               env:
                 - name: DB_USER
@@ -40,11 +60,26 @@ spec:
                   value: {{ .app.harness.database.pass }}
                 - name: DB_HOST
                   value: {{ .app.harness.database.name }}
-                - name: KEEP_DAYS
+                - name: BACKUP_KEEP_DAYS
                   value: {{ .app.harness.database.backup.keep_days | quote }}
+                - name: BACKUP_KEEP_WEEKS
+                  value: {{ .app.harness.database.backup.keep_weeks |quote }}
+                - name: BACKUP_KEEP_MONTHS
+                  value: {{ .app.harness.database.backup.keep_months | quote }}
+                - name: BACKUP_SUFFIX
+                  value: ".gz"
+                - name: BACKUP_DIR
+                  value: "/backups"
               volumeMounts:
                 - name: "{{ .app.harness.database.name }}-backup"
                   mountPath: /backups
+              resources:
+                requests:
+                  memory: {{ .app.harness.database.backup.resources.requests.memory | default "32Mi" }}
+                  cpu: {{ .app.harness.database.backup.resources.requests.cpu | default "25Mi" }}
+                limits:
+                  memory: {{ .app.harness.database.backup.resources.limits.memory | default "64Mi" }}
+                  cpu: {{ .app.harness.database.backup.resources.limits.cpu | default "50mi" }}
           restartPolicy: OnFailure
           volumes:
             - name: "{{ .app.harness.database.name }}-backup"

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-mongo-backup.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-mongo-backup.yaml
@@ -13,13 +13,12 @@ spec:
             - name: "{{ .app.harness.database.name }}-backup"
               image: {{ .app.harness.database.mongo.image }}
               imagePullPolicy: IfNotPresent
-              command: ["/bin/sh"]
+              command: ["/bin/bash"]
               args:
                 - -c
                 - | {{ range .root.Files.Lines "files/db-mongo-backup.sh" }}
                   {{ . }}
                 {{ end }}
-
               env:
                 - name: DB_USER
                   value: {{ .app.harness.database.user }}

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-mongo-backup.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-mongo-backup.yaml
@@ -16,12 +16,23 @@ spec:
               command: ["/bin/sh"]
               args:
                 - -c
-                - >-
-                  echo Started backup;
-                  FILE=/backups/$(date "+%Y-%m-%d").gz;
-                  /usr/bin/mongodump -h $DB_HOST -u $DB_USER -p $DB_PASS --archive=$FILE --gzip;
-                  ls -lisah /backups;
-                  echo Finished backup;
+                - |
+                  /bin/bash << 'EOF'
+                  # Create new backup
+                  echo Started backup
+                  FILE=/backups/$(date "+%Y-%m-%d-%H-%M").gz
+                  /usr/bin/mongodump -h $DB_HOST -u $DB_USER -p $DB_PASS --archive=$FILE --gzip
+                  echo Added new backup $FILE
+
+                  # Cleanup procedure
+                  EXISTING=$(find backups/*.gz | wc -l)
+                  echo Found $EXISTING backups
+                  if [ $EXISTING -gt $KEEP_DAYS ]; then
+                      echo Start cleaing ...
+                      find backups/* -mtime +$KEEP_DAYS -delete -print
+                      echo Finished cleaning
+                  fi
+                  EOF
               env:
                 - name: DB_USER
                   value: {{ .app.harness.database.user }}
@@ -29,6 +40,8 @@ spec:
                   value: {{ .app.harness.database.pass }}
                 - name: DB_HOST
                   value: {{ .app.harness.database.name }}
+                - name: KEEP_DAYS
+                  value: {{ .app.harness.database.backup.keep_days | quote }}
               volumeMounts:
                 - name: "{{ .app.harness.database.name }}-backup"
                   mountPath: /backups

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-mongo-backup.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-mongo-backup.yaml
@@ -28,15 +28,15 @@ spec:
                 - name: DB_HOST
                   value: {{ .app.harness.database.name }}
                 - name: BACKUP_KEEP_DAYS
-                  value: {{ .app.harness.database.backup.keep_days | quote }}
+                  value: {{ .root.Values.backup.keep_days | quote }}
                 - name: BACKUP_KEEP_WEEKS
-                  value: {{ .app.harness.database.backup.keep_weeks |quote }}
+                  value: {{ .root.Values.backup.keep_weeks | quote }}
                 - name: BACKUP_KEEP_MONTHS
-                  value: {{ .app.harness.database.backup.keep_months | quote }}
+                  value: {{ .root.Values.backup.keep_months | quote }}
                 - name: BACKUP_SUFFIX
-                  value: ".gz"
+                  value: {{ .root.Values.backup.suffix | quote }}
                 - name: BACKUP_DIR
-                  value: "/backups"
+                  value: {{ .root.Values.backup.dir | quote }}
               volumeMounts:
                 - name: "{{ .app.harness.database.name }}-backup"
                   mountPath: /backups

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-mongo-backup.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-mongo-backup.yaml
@@ -1,0 +1,40 @@
+{{ define "deploy_utils.database.mongo.backup"}}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: "{{ .app.harness.database.name }}-backup"
+spec:
+  schedule: {{ .root.Values.backup.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: mongodb-backup
+              image: {{ .app.harness.database.mongo.image }}
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh"]
+              args:
+                - -c
+                - >-
+                  echo Started backup;
+                  FILE=/backups/$(date "+%Y-%m-%d").gz;
+                  /usr/bin/mongodump -h $DB_HOST -u $DB_USER -p $DB_PASS --archive=$FILE --gzip;
+                  ls -lisah /backups;
+                  echo Finished backup;
+              env:
+                - name: DB_USER
+                  value: {{ .app.harness.database.user }}
+                - name: DB_PASS
+                  value: {{ .app.harness.database.pass }}
+                - name: DB_HOST
+                  value: {{ .app.harness.database.name }}
+              volumeMounts:
+                - name: "{{ .app.harness.database.name }}-backup"
+                  mountPath: /backups
+          restartPolicy: OnFailure
+          volumes:
+            - name: "{{ .app.harness.database.name }}-backup"
+              persistentVolumeClaim:
+                claimName: "{{ .app.harness.database.name }}-backup"
+{{ end }}

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-mongo-backup.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-mongo-backup.yaml
@@ -42,11 +42,11 @@ spec:
                   mountPath: /backups
               resources:
                 requests:
-                  memory: {{ .app.harness.database.backup.resources.requests.memory | default "32Mi" }}
-                  cpu: {{ .app.harness.database.backup.resources.requests.cpu | default "25Mi" }}
+                  memory: {{ .root.Values.backup.resources.requests.memory | default "32Mi" }}
+                  cpu: {{ .root.Values.backup.resources.requests.cpu | default "25Mi" }}
                 limits:
-                  memory: {{ .app.harness.database.backup.resources.limits.memory | default "64Mi" }}
-                  cpu: {{ .app.harness.database.backup.resources.limits.cpu | default "50mi" }}
+                  memory: {{ .root.Values.backup.resources.limits.memory | default "64Mi" }}
+                  cpu: {{ .root.Values.backup.resources.limits.cpu | default "50mi" }}
           restartPolicy: OnFailure
           volumes:
             - name: "{{ .app.harness.database.name }}-backup"

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-mongo-backup.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-mongo-backup.yaml
@@ -16,43 +16,10 @@ spec:
               command: ["/bin/sh"]
               args:
                 - -c
-                - |
-                  /bin/bash << 'EOF'
-                  KEEP_DAYS=${BACKUP_KEEP_DAYS}
-                  KEEP_WEEKS=`expr $(((${BACKUP_KEEP_WEEKS} * 7) + 1))`
-                  KEEP_MONTHS=`expr $(((${BACKUP_KEEP_MONTHS} * 31) + 1))`
+                - | {{ range .root.Files.Lines "files/db-mongo-backup.sh" }}
+                  {{ . }}
+                {{ end }}
 
-                  mkdir -p "${BACKUP_DIR}/daily/" "${BACKUP_DIR}/weekly/" "${BACKUP_DIR}/monthly/"
-                  DFILE="${BACKUP_DIR}/daily/`date +%Y-%m-%d-%H%M%S`${BACKUP_SUFFIX}"
-                  WFILE="${BACKUP_DIR}/weekly/`date +%G-%V`${BACKUP_SUFFIX}"
-                  MFILE="${BACKUP_DIR}/monthly/`date +%Y-%m`${BACKUP_SUFFIX}"
-
-                  # Dump mongo database
-                  /usr/bin/mongodump -h $DB_HOST -u $DB_USER -p $DB_PASS --archive=$DFILE --gzip
-                  ls backups/*
-
-                  # Use hardlink instead of copy to save space
-                  if [ -d "${DFILE}" ]; then
-                      WFILENEW="${WFILE}-new"
-                      MFILENEW="${MFILE}-new"
-                      rm -rf "${WFILENEW}" "${MFILENEW}"
-                      mkdir "${WFILENEW}" "${MFILENEW}"
-                      ln -f "${DFILE}/"* "${WFILENEW}/"
-                      ln -f "${DFILE}/"* "${MFILENEW}/"
-                      rm -rf "${WFILE}" "${MFILE}"
-                      mv -v "${WFILENEW}" "${WFILE}"
-                      mv -v "${MFILENEW}" "${MFILE}"
-                  else
-                      ln -vf "${DFILE}" "${WFILE}"
-                      ln -vf "${DFILE}" "${MFILE}"
-                  fi
-
-                  # Clean old files
-                  echo "Cleaning backups older than ${KEEP_DAYS} ..."
-                  find "${BACKUP_DIR}/daily" -maxdepth 1 -mtime +${KEEP_DAYS} -name "*${BACKUP_SUFFIX}" -print -delete
-                  find "${BACKUP_DIR}/weekly" -maxdepth 1 -mtime +${KEEP_WEEKS} -name "*${BACKUP_SUFFIX}" -print -delete
-                  find "${BACKUP_DIR}/monthly" -maxdepth 1 -mtime +${KEEP_MONTHS} -name "*${BACKUP_SUFFIX}" -print -delete
-                  EOF
               env:
                 - name: DB_USER
                   value: {{ .app.harness.database.user }}

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-mongo.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-mongo.yaml
@@ -1,0 +1,26 @@
+{{- define "deploy_utils.database.mongo" }}
+        image: {{ .app.harness.database.mongo.image }}
+        env:
+          - name: MONGO_INITDB_ROOT_USERNAME
+            value: {{ .app.harness.database.user | quote }}
+          - name: MONGO_INITDB_ROOT_PASSWORD
+            value: {{ .app.harness.database.pass | quote }}
+        livenessProbe:
+          exec:
+            command:
+              - mongo
+              - --eval
+              - "db.adminCommand('ping')"
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 6
+        readinessProbe:
+          exec:
+            command:
+              - mongo
+              - --eval
+              - "db.adminCommand('ping')"
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 6
+{{- end }}

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-neo4j-backup.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-neo4j-backup.yaml
@@ -1,0 +1,2 @@
+{{- define "deploy_utils.database.neo4j.backup" }}
+{{- end }}

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-neo4j.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-neo4j.yaml
@@ -1,0 +1,20 @@
+{{- define "deploy_utils.database.neo4j" }}
+        image: {{ .app.harness.database.neo4j.image }}
+        env:
+          - name: NEO4J_dbms_directories_data
+            value: /data/db/data
+          - name: NEO4J_dbms_directories_logs
+            value: /data/db/logs
+          - name: NEO4J_dbms_directories_metrics
+            value: /data/db/metrics
+          - name: NEO4J_dbms_memory_size
+            value: {{ .app.harness.database.neo4j.memory.size }}
+          - name: NEO4J_dbms_memory_pagecache_size
+            value: {{ .app.harness.database.neo4j.memory.pagecache.size }}
+          - name: NEO4J_dbms_memory_heap_initial__size
+            value: {{ .app.harness.database.neo4j.memory.heap.initial }}
+          - name: NEO4J_dbms_memory_heap_max__size
+            value: {{ .app.harness.database.neo4j.memory.heap.max }}
+          - name: NEO4J_dbms_security_auth__enabled
+            value: {{ .app.harness.database.neo4j.dbms_security_auth_enabled | quote }}
+{{- end }}

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-postgres-backup.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-postgres-backup.yaml
@@ -16,7 +16,7 @@ spec:
             - name: "{{ .app.harness.database.name }}-backup"
               imagePullPolicy: IfNotPresent
               image: prodrigestivill/postgres-backup-local
-              command: ["/bin/sh"]
+              command: ["/bin/bash"]
               args: ["-c" , "./backup.sh"]
               env:
                 - name: POSTGRES_HOST

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-postgres-backup.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-postgres-backup.yaml
@@ -1,62 +1,53 @@
-{{ define "deploy_utils.database.postgres.backup" }}
-apiVersion: apps/v1
-kind: Deployment
+{{ define "deploy_utils.database.postgres.backup"}}
+apiVersion: batch/v1beta1
+kind: CronJob
 metadata:
   name: "{{ .app.harness.database.name }}-backup"
-  namespace: {{ .root.Values.namespace }}
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: "{{ .app.harness.database.name }}-backup"
-  template:
-    metadata:
-      labels:
-        app: "{{ .app.harness.database.name }}-backup"
+  schedule: {{ .root.Values.backup.schedule | quote }}
+  jobTemplate:
     spec:
-      securityContext:
-        runAsUser: 999
-        runAsGroup: 999
-      containers:
-        - name: "{{ .app.harness.database.name }}-backup"
-          imagePullPolicy: IfNotPresent
-          image: prodrigestivill/postgres-backup-local
-          env:
-            - name: POSTGRES_HOST
-              value: {{ .app.harness.database.name | quote }}
-            - name: POSTGRES_DB
-              value: {{ (index .app.harness.database .app.harness.database.type).initialdb | quote }}
-            - name: POSTGRES_USER
-              value: {{ .app.harness.database.user | quote }}
-            - name: POSTGRES_PASSWORD
-              value: {{ .app.harness.database.pass | quote }}
-            - name: SCHEDULE
-              value: {{ .root.Values.backup.schedule | quote }}
-            - name: BACKUP_KEEP_DAYS
-              value: {{ .app.harness.database.backup.keep_days | quote }}
-            - name: BACKUP_KEEP_WEEKS
-              value: {{ .app.harness.database.backup.keep_weeks |quote }}
-            - name: BACKUP_KEEP_MONTHS
-              value: {{ .app.harness.database.backup.keep_months | quote }}
-            - name: HEALTHCHECK_PORT
-              value: {{ .app.harness.database.backup.healthcheck_port | quote }}
-          resources:
-            requests:
-              memory: {{ .app.harness.database.backup.resources.requests.memory | default "32Mi" }}
-              cpu: {{ .app.harness.database.backup.resources.requests.cpu | default "25Mi" }}
-            limits:
-              memory: {{ .app.harness.database.backup.resources.limits.memory | default "64Mi" }}
-              cpu: {{ .app.harness.database.backup.resources.limits.cpu | default "50mi" }}
-          livenessProbe:
-            httpGet:
-              path: /
-              port: {{ .app.harness.database.backup.healthcheck_port }}
-            initialDelaySeconds: 15
-          volumeMounts:
+      template:
+        spec:
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 999
+          containers:
             - name: "{{ .app.harness.database.name }}-backup"
-              mountPath: /backups
-      volumes:
-        - name: "{{ .app.harness.database.name }}-backup"
-          persistentVolumeClaim:
-            claimName: "{{ .app.harness.database.name }}-backup"
-{{ end}}
+              imagePullPolicy: IfNotPresent
+              image: prodrigestivill/postgres-backup-local
+              command: ["/bin/sh"]
+              args: ["-c" , "./backup.sh"]
+              env:
+                - name: POSTGRES_HOST
+                  value: {{ .app.harness.database.name | quote }}
+                - name: POSTGRES_DB
+                  value: {{ (index .app.harness.database .app.harness.database.type).initialdb | quote }}
+                - name: POSTGRES_USER
+                  value: {{ .app.harness.database.user | quote }}
+                - name: POSTGRES_PASSWORD
+                  value: {{ .app.harness.database.pass | quote }}
+                - name: SCHEDULE
+                  value: {{ .root.Values.backup.schedule | quote }}
+                - name: BACKUP_KEEP_DAYS
+                  value: {{ .app.harness.database.backup.keep_days | quote }}
+                - name: BACKUP_KEEP_WEEKS
+                  value: {{ .app.harness.database.backup.keep_weeks |quote }}
+                - name: BACKUP_KEEP_MONTHS
+                  value: {{ .app.harness.database.backup.keep_months | quote }}
+              volumeMounts:
+                - name: "{{ .app.harness.database.name }}-backup"
+                  mountPath: /backups
+              resources:
+                requests:
+                  memory: {{ .app.harness.database.backup.resources.requests.memory | default "32Mi" }}
+                  cpu: {{ .app.harness.database.backup.resources.requests.cpu | default "25Mi" }}
+                limits:
+                  memory: {{ .app.harness.database.backup.resources.limits.memory | default "64Mi" }}
+                  cpu: {{ .app.harness.database.backup.resources.limits.cpu | default "50mi" }}
+          restartPolicy: OnFailure
+          volumes:
+            - name: "{{ .app.harness.database.name }}-backup"
+              persistentVolumeClaim:
+                claimName: "{{ .app.harness.database.name }}-backup"
+  {{ end }}

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-postgres-backup.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-postgres-backup.yaml
@@ -1,0 +1,62 @@
+{{ define "deploy_utils.database.postgres.backup" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ .app.harness.database.name }}-backup"
+  namespace: {{ .root.Values.namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "{{ .app.harness.database.name }}-backup"
+  template:
+    metadata:
+      labels:
+        app: "{{ .app.harness.database.name }}-backup"
+    spec:
+      securityContext:
+        runAsUser: 999
+        runAsGroup: 999
+      containers:
+        - name: "{{ .app.harness.database.name }}-backup"
+          imagePullPolicy: IfNotPresent
+          image: prodrigestivill/postgres-backup-local
+          env:
+            - name: POSTGRES_HOST
+              value: {{ .app.harness.database.name | quote }}
+            - name: POSTGRES_DB
+              value: {{ (index .app.harness.database .app.harness.database.type).initialdb | quote }}
+            - name: POSTGRES_USER
+              value: {{ .app.harness.database.user | quote }}
+            - name: POSTGRES_PASSWORD
+              value: {{ .app.harness.database.pass | quote }}
+            - name: SCHEDULE
+              value: {{ .root.Values.backup.schedule | quote }}
+            - name: BACKUP_KEEP_DAYS
+              value: {{ .app.harness.database.backup.keep_days | quote }}
+            - name: BACKUP_KEEP_WEEKS
+              value: {{ .app.harness.database.backup.keep_weeks |quote }}
+            - name: BACKUP_KEEP_MONTHS
+              value: {{ .app.harness.database.backup.keep_months | quote }}
+            - name: HEALTHCHECK_PORT
+              value: {{ .app.harness.database.backup.healthcheck_port | quote }}
+          resources:
+            requests:
+              memory: {{ .app.harness.database.backup.resources.requests.memory | default "32Mi" }}
+              cpu: {{ .app.harness.database.backup.resources.requests.cpu | default "25Mi" }}
+            limits:
+              memory: {{ .app.harness.database.backup.resources.limits.memory | default "64Mi" }}
+              cpu: {{ .app.harness.database.backup.resources.limits.cpu | default "50mi" }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .app.harness.database.backup.healthcheck_port }}
+            initialDelaySeconds: 15
+          volumeMounts:
+            - name: "{{ .app.harness.database.name }}-backup"
+              mountPath: /backups
+      volumes:
+        - name: "{{ .app.harness.database.name }}-backup"
+          persistentVolumeClaim:
+            claimName: "{{ .app.harness.database.name }}-backup"
+{{ end}}

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-postgres-backup.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-postgres-backup.yaml
@@ -50,4 +50,4 @@ spec:
             - name: "{{ .app.harness.database.name }}-backup"
               persistentVolumeClaim:
                 claimName: "{{ .app.harness.database.name }}-backup"
-  {{ end }}
+{{ end }}

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-postgres-backup.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-postgres-backup.yaml
@@ -44,11 +44,11 @@ spec:
                   mountPath: /backups
               resources:
                 requests:
-                  memory: {{ .app.harness.database.backup.resources.requests.memory | default "32Mi" }}
-                  cpu: {{ .app.harness.database.backup.resources.requests.cpu | default "25Mi" }}
+                  memory: {{ .root.Values.backup.resources.requests.memory | default "32Mi" }}
+                  cpu: {{ .root.Values.backup.resources.requests.cpu | default "25Mi" }}
                 limits:
-                  memory: {{ .app.harness.database.backup.resources.limits.memory | default "64Mi" }}
-                  cpu: {{ .app.harness.database.backup.resources.limits.cpu | default "50mi" }}
+                  memory: {{ .root.Values.backup.resources.limits.memory | default "64Mi" }}
+                  cpu: {{ .root.Values.backup.resources.limits.cpu | default "50mi" }}
           restartPolicy: OnFailure
           volumes:
             - name: "{{ .app.harness.database.name }}-backup"

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-postgres-backup.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-postgres-backup.yaml
@@ -30,11 +30,15 @@ spec:
                 - name: SCHEDULE
                   value: {{ .root.Values.backup.schedule | quote }}
                 - name: BACKUP_KEEP_DAYS
-                  value: {{ .app.harness.database.backup.keep_days | quote }}
+                  value: {{ .root.Values.backup.keep_days | quote }}
                 - name: BACKUP_KEEP_WEEKS
-                  value: {{ .app.harness.database.backup.keep_weeks |quote }}
+                  value: {{ .root.Values.backup.keep_weeks |quote }}
                 - name: BACKUP_KEEP_MONTHS
-                  value: {{ .app.harness.database.backup.keep_months | quote }}
+                  value: {{ .root.Values.backup.keep_months | quote }}
+                - name: BACKUP_SUFFIX
+                  value: {{ .root.Values.backup.suffix | quote }}
+                - name: BACKUP_DIR
+                  value: {{ .root.Values.backup.dir | quote }}
               volumeMounts:
                 - name: "{{ .app.harness.database.name }}-backup"
                   mountPath: /backups

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-postgres.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database-postgres.yaml
@@ -1,0 +1,12 @@
+{{- define "deploy_utils.database.postgres" }}
+        image: {{ .app.harness.database.postgres.image }}
+        env:
+          - name: POSTGRES_DB
+            value: {{ .app.harness.database.postgres.initialdb | quote }}
+          - name: POSTGRES_USER
+            value: {{ .app.harness.database.user | quote }}
+          - name: POSTGRES_PASSWORD
+            value: {{ .app.harness.database.pass | quote }}
+          - name: PGDATA
+            value: /data/db/pgdata
+{{- end }}

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
@@ -126,6 +126,9 @@ spec:
       labels:
         app: "{{ .app.harness.database.name }}-backup"
     spec:
+      securityContext:
+        runAsUser: 999
+        runAsGroup: 999
       containers:
         - name: "{{ .app.harness.database.name }}-backup"
           imagePullPolicy: IfNotPresent

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
@@ -1,64 +1,5 @@
 {{/* Services */}}
-{{- define "deploy_utils.database.postgres" }}
-        image: {{ .app.harness.database.postgres.image }}
-        env:
-        - name: POSTGRES_DB
-          value: {{ .app.harness.database.postgres.initialdb | quote }}
-        - name: POSTGRES_USER
-          value: {{ .app.harness.database.user | quote }}
-        - name: POSTGRES_PASSWORD
-          value: {{ .app.harness.database.pass | quote }}
-        - name: PGDATA
-          value: /data/db/pgdata
-{{- end }}
-{{- define "deploy_utils.database.mongo" }}
-        image: {{ .app.harness.database.mongo.image }}
-        env:
-          - name: MONGO_INITDB_ROOT_USERNAME
-            value: {{ .app.harness.database.user | quote }}
-          - name: MONGO_INITDB_ROOT_PASSWORD
-            value: {{ .app.harness.database.pass | quote }}
-        livenessProbe:
-          exec:
-            command:
-            - mongo
-            - --eval
-            - "db.adminCommand('ping')"
-          initialDelaySeconds: 30
-          timeoutSeconds: 5
-          failureThreshold: 6
-        readinessProbe:
-          exec:
-            command:
-            - mongo
-            - --eval
-            - "db.adminCommand('ping')"
-          initialDelaySeconds: 5
-          timeoutSeconds: 5
-          failureThreshold: 6
-{{- end }}
-{{- define "deploy_utils.database.neo4j" }}
-        image: {{ .app.harness.database.neo4j.image }}
-        env:
-          - name: NEO4J_dbms_directories_data
-            value: /data/db/data
-          - name: NEO4J_dbms_directories_logs
-            value: /data/db/logs
-          - name: NEO4J_dbms_directories_metrics
-            value: /data/db/metrics
-          - name: NEO4J_dbms_memory_size
-            value: {{ .app.harness.database.neo4j.memory.size }}
-          - name: NEO4J_dbms_memory_pagecache_size
-            value: {{ .app.harness.database.neo4j.memory.pagecache.size }}
-          - name: NEO4J_dbms_memory_heap_initial__size
-            value: {{ .app.harness.database.neo4j.memory.heap.initial }}
-          - name: NEO4J_dbms_memory_heap_max__size
-            value: {{ .app.harness.database.neo4j.memory.heap.max }}
-          - name: NEO4J_dbms_security_auth__enabled
-            value: {{ .app.harness.database.neo4j.dbms_security_auth_enabled | quote }}
-{{- end }}
 {{- define "deploy_utils.database" }}
----
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -110,109 +51,8 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .app.harness.database.name | quote }}
 ---
-{{ if .root.Values.backup.active }}
-  {{ if eq .app.harness.database.type "postgres" }}
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: "{{ .app.harness.database.name }}-backup"
-  namespace: {{ .root.Values.namespace }}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: "{{ .app.harness.database.name }}-backup"
-  template:
-    metadata:
-      labels:
-        app: "{{ .app.harness.database.name }}-backup"
-    spec:
-      securityContext:
-        runAsUser: 999
-        runAsGroup: 999
-      containers:
-        - name: "{{ .app.harness.database.name }}-backup"
-          imagePullPolicy: IfNotPresent
-          image: prodrigestivill/postgres-backup-local
-          env:
-            - name: POSTGRES_HOST
-              value: {{ .app.harness.database.name | quote }}
-            - name: POSTGRES_DB
-              value: {{ (index .app.harness.database .app.harness.database.type).initialdb | quote }}
-            - name: POSTGRES_USER
-              value: {{ .app.harness.database.user | quote }}
-            - name: POSTGRES_PASSWORD
-              value: {{ .app.harness.database.pass | quote }}
-            - name: SCHEDULE
-              value: {{ .root.Values.backup.schedule | quote }}
-            - name: BACKUP_KEEP_DAYS
-              value: {{ .app.harness.database.backup.keep_days | quote }}
-            - name: BACKUP_KEEP_WEEKS
-              value: {{ .app.harness.database.backup.keep_weeks |quote }}
-            - name: BACKUP_KEEP_MONTHS
-              value: {{ .app.harness.database.backup.keep_months | quote }}
-            - name: HEALTHCHECK_PORT
-              value: {{ .app.harness.database.backup.healthcheck_port | quote }}
-          resources:
-            requests:
-              memory: {{ .app.harness.database.backup.resources.requests.memory | default "32Mi" }}
-              cpu: {{ .app.harness.database.backup.resources.requests.cpu | default "25Mi" }}
-            limits:
-              memory: {{ .app.harness.database.backup.resources.limits.memory | default "64Mi" }}
-              cpu: {{ .app.harness.database.backup.resources.limits.cpu | default "50mi" }}
-          livenessProbe:
-            httpGet:
-              path: /
-              port: {{ .app.harness.database.backup.healthcheck_port }}
-            initialDelaySeconds: 15
-          volumeMounts:
-            - name: "{{ .app.harness.database.name }}-backup"
-              mountPath: /backups
-      volumes:
-        - name: "{{ .app.harness.database.name }}-backup"
-          persistentVolumeClaim:
-            claimName: "{{ .app.harness.database.name }}-backup"
-  {{ end }}
-  {{ if eq .app.harness.database.type "mongo" }}
-apiVersion: batch/v1beta1
-kind: CronJob
-metadata:
-  name: "{{ .app.harness.database.name }}-backup"
-spec:
-  schedule: {{ .app.harness.database.backup.schedule | quote }}
-  jobTemplate:
-    spec:
-      template:
-        spec:
-          containers:
-            - name: mongodb-backup
-              image: {{ .app.harness.database.mongo.image }}
-              imagePullPolicy: IfNotPresent
-              command: ["/bin/sh"]
-              args:
-                - -c
-                - >-
-                  echo Started backup;
-                  FILE=/backups/$(date "+%Y-%m-%d").gz;
-                  /usr/bin/mongodump -h $DB_HOST -u $DB_USER -p $DB_PASS --archive=$FILE --gzip;
-                  ls -lisah /backups;
-                  echo Finished backup;
-              env:
-                - name: DB_USER
-                  value: {{ .app.harness.database.user }}
-                - name: DB_PASS
-                  value: {{ .app.harness.database.pass }}
-                - name: DB_HOST
-                  value: {{ .app.harness.database.name }}
-              volumeMounts:
-                - name: "{{ .app.harness.database.name }}-backup"
-                  mountPath: /backups
-          restartPolicy: OnFailure
-          volumes:
-            - name: "{{ .app.harness.database.name }}-backup"
-              persistentVolumeClaim:
-                claimName: "{{ .app.harness.database.name }}-backup"
-  {{ end }}
+{{- if .root.Values.backup.active }}
+{{- include (print "deploy_utils.database." .app.harness.database.type ".backup") . }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -225,8 +65,8 @@ spec:
   resources:
     requests:
       storage: {{ .app.harness.database.size }}
-{{ end }}
 ---
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -245,7 +85,7 @@ spec:
     port: {{ $port.port }}
   {{- end }}
 ---
-{{- end }}
+{{ end }}
 {{- range $app := .Values.apps }}
   {{- if $app.harness.database.auto  }}
      {{ include "deploy_utils.database" (dict "root" $ "app" $app) }}

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
@@ -171,6 +171,47 @@ spec:
         - name: "{{ .app.harness.database.name }}-backup"
           persistentVolumeClaim:
             claimName: "{{ .app.harness.database.name }}-backup"
+{{ end }}
+{{ if eq .app.harness.database.type "mongo" }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: "{{ .app.harness.database.name }}-backup"
+spec:
+  schedule: {{ .app.harness.database.backup.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: mongodb-backup
+              image: {{ .app.harness.database.mongo.image }}
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh"]
+              args:
+                - -c
+                - >-
+                  echo Started backup;
+                  FILE=/backups/$(date "+%Y-%m-%d").gz;
+                  /usr/bin/mongodump -h $DB_HOST -u $DB_USER -p $DB_PASS --archive=$FILE --gzip;
+                  ls -lisah /backups;
+                  echo Finished backup;
+              env:
+                - name: DB_USER
+                  value: {{ .app.harness.database.user }}
+                - name: DB_PASS
+                  value: {{ .app.harness.database.pass }}
+                - name: DB_HOST
+                  value: {{ .app.harness.database.name }}
+              volumeMounts:
+                - name: "{{ .app.harness.database.name }}-backup"
+                  mountPath: /backups
+          restartPolicy: OnFailure
+          volumes:
+            - name: "{{ .app.harness.database.name }}-backup"
+              persistentVolumeClaim:
+                claimName: "{{ .app.harness.database.name }}-backup"
+{{ end }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -184,7 +225,6 @@ spec:
     requests:
       storage: {{ .app.harness.database.size }}
 ---
-{{ end }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
@@ -110,6 +110,66 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .app.harness.database.name | quote }}
 ---
+{{ if eq .app.harness.database.type "postgres" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ .app.harness.database.name }}-backup"
+  namespace: {{ .root.Values.namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "{{ .app.harness.database.name }}-backup"
+  template:
+    metadata:
+      labels:
+        app: "{{ .app.harness.database.name }}-backup"
+    spec:
+      containers:
+        - name: "{{ .app.harness.database.name }}-backup"
+          imagePullPolicy: IfNotPresent
+          image: prodrigestivill/postgres-backup-local
+          env:
+            - name: POSTGRES_HOST
+              value: {{ .app.harness.database.name | quote }}
+            - name: POSTGRES_DB
+              value: {{ (index .app.harness.database .app.harness.database.type).initialdb | quote }}
+            - name: POSTGRES_USER
+              value: {{ .app.harness.database.user | quote }}
+            - name: POSTGRES_PASSWORD
+              value: {{ .app.harness.database.pass | quote }}
+            - name: SCHEDULE
+              value: {{ .app.harness.database.backup.schedule | quote }}
+            - name: BACKUP_KEEP_DAYS
+              value: {{ .app.harness.database.backup.keep_days | quote }}
+            - name: BACKUP_KEEP_WEEKS
+              value: {{ .app.harness.database.backup.keep_weeks |quote }}
+            - name: BACKUP_KEEP_MONTHS
+              value: {{ .app.harness.database.backup.keep_months | quote }}
+            - name: HEALTHCHECK_PORT
+              value: {{ .app.harness.database.backup.healthcheck_port | quote }}
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "25m"
+            limits:
+              memory: "64Mi"
+              cpu: "50m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .app.harness.database.backup.healthcheck_port }}
+            initialDelaySeconds: 15
+          volumeMounts:
+            - name: {{ .app.harness.database.name | quote }}
+              mountPath: /data/db
+      volumes:
+        - name: {{ .app.harness.database.name | quote }}
+          persistentVolumeClaim:
+            claimName: {{ .app.harness.database.name | quote }}
+---
+{{ end }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
@@ -165,12 +165,24 @@ spec:
               port: {{ .app.harness.database.backup.healthcheck_port }}
             initialDelaySeconds: 15
           volumeMounts:
-            - name: {{ .app.harness.database.name | quote }}
-              mountPath: /data/db
+            - name: "{{ .app.harness.database.name }}-backup"
+              mountPath: /backups
       volumes:
-        - name: {{ .app.harness.database.name | quote }}
+        - name: "{{ .app.harness.database.name }}-backup"
           persistentVolumeClaim:
-            claimName: {{ .app.harness.database.name | quote }}
+            claimName: "{{ .app.harness.database.name }}-backup"
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: "{{ .app.harness.database.name }}-backup"
+  namespace: {{ .root.Values.namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .app.harness.database.size }}
 ---
 {{ end }}
 apiVersion: v1

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
@@ -110,7 +110,8 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .app.harness.database.name | quote }}
 ---
-{{ if eq .app.harness.database.type "postgres" }}
+{{ if .root.Values.backup.active }}
+  {{ if eq .app.harness.database.type "postgres" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -143,7 +144,7 @@ spec:
             - name: POSTGRES_PASSWORD
               value: {{ .app.harness.database.pass | quote }}
             - name: SCHEDULE
-              value: {{ .app.harness.database.backup.schedule | quote }}
+              value: {{ .root.Values.backup.schedule | quote }}
             - name: BACKUP_KEEP_DAYS
               value: {{ .app.harness.database.backup.keep_days | quote }}
             - name: BACKUP_KEEP_WEEKS
@@ -171,8 +172,8 @@ spec:
         - name: "{{ .app.harness.database.name }}-backup"
           persistentVolumeClaim:
             claimName: "{{ .app.harness.database.name }}-backup"
-{{ end }}
-{{ if eq .app.harness.database.type "mongo" }}
+  {{ end }}
+  {{ if eq .app.harness.database.type "mongo" }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -211,7 +212,7 @@ spec:
             - name: "{{ .app.harness.database.name }}-backup"
               persistentVolumeClaim:
                 claimName: "{{ .app.harness.database.name }}-backup"
-{{ end }}
+  {{ end }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -224,6 +225,7 @@ spec:
   resources:
     requests:
       storage: {{ .app.harness.database.size }}
+{{ end }}
 ---
 apiVersion: v1
 kind: Service

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
@@ -154,11 +154,11 @@ spec:
               value: {{ .app.harness.database.backup.healthcheck_port | quote }}
           resources:
             requests:
-              memory: "32Mi"
-              cpu: "25m"
+              memory: {{ .app.harness.database.backup.resources.requests.memory | default "32Mi" }}
+              cpu: {{ .app.harness.database.backup.resources.requests.cpu | default "25Mi" }}
             limits:
-              memory: "64Mi"
-              cpu: "50m"
+              memory: {{ .app.harness.database.backup.resources.limits.memory | default "64Mi" }}
+              cpu: {{ .app.harness.database.backup.resources.limits.cpu | default "50mi" }}
           livenessProbe:
             httpGet:
               path: /

--- a/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
@@ -71,11 +71,3 @@ harness:
       limits:
         memory: "2Gi"
         cpu: "1000m"
-    backup:
-      resources:
-        requests:
-          memory: "32Mi"
-          cpu: "25m"
-        limits:
-          memory: "64Mi"
-          cpu: "50m"

--- a/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
@@ -75,7 +75,6 @@ harness:
       keep_days: "7"
       keep_weeks: "4"
       keep_months: "6"
-      healthcheck_port: 8080
       resources:
         requests:
           memory: "32Mi"

--- a/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
@@ -72,7 +72,6 @@ harness:
         memory: "2Gi"
         cpu: "1000m"
     backup:
-      schedule: "@daily"
       keep_days: "7"
       keep_weeks: "4"
       keep_months: "6"

--- a/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
@@ -72,9 +72,6 @@ harness:
         memory: "2Gi"
         cpu: "1000m"
     backup:
-      keep_days: "7"
-      keep_weeks: "4"
-      keep_months: "6"
       resources:
         requests:
           memory: "32Mi"

--- a/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
@@ -77,3 +77,10 @@ harness:
       keep_weeks: "4"
       keep_months: "6"
       healthcheck_port: 8080
+      resources:
+        requests:
+          memory: "32Mi"
+          cpu: "25m"
+        limits:
+          memory: "64Mi"
+          cpu: "50m"

--- a/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/value-template.yaml
@@ -71,3 +71,9 @@ harness:
       limits:
         memory: "2Gi"
         cpu: "1000m"
+    backup:
+      schedule: "@daily"
+      keep_days: "7"
+      keep_weeks: "4"
+      keep_months: "6"
+      healthcheck_port: 8080

--- a/utilities/cloudharness_utilities/deployment-configuration/values-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/values-template.yaml
@@ -25,3 +25,6 @@ ingress:
   ssl_redirect: true
   letsencrypt:
     email: filippo@metacell.us
+backup:
+  active: false
+  schedule: "@daily"

--- a/utilities/cloudharness_utilities/deployment-configuration/values-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/values-template.yaml
@@ -26,10 +26,17 @@ ingress:
   letsencrypt:
     email: filippo@metacell.us
 backup:
-  active: false
+  active: true
   keep_days: "7"
   keep_weeks: "4"
   keep_months: "6"
   schedule: "@daily"
   suffix: ".gz"
   dir: "/backups"
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "25m"
+    limits:
+      memory: "64Mi"
+      cpu: "50m"

--- a/utilities/cloudharness_utilities/deployment-configuration/values-template.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/values-template.yaml
@@ -27,4 +27,9 @@ ingress:
     email: filippo@metacell.us
 backup:
   active: false
+  keep_days: "7"
+  keep_weeks: "4"
+  keep_months: "6"
   schedule: "@daily"
+  suffix: ".gz"
+  dir: "/backups"


### PR DESCRIPTION
* DB Backup is stored on a different persistence volume claim than DB
* Backup Deployment and Backup PVC only created if DB type is postgres
* Ensured that Pod runs as postgres user not as root

Manual Testing
* Tested new backup pod by specifying "@every 5m" as schedule
* Checked /backups folder if backup was created
* Verify created files: Copied DB backup to local filesystem, uploaded again to DB pod and imported backup as new DB name with `psql db_name < dump.sql`, worked without problem