### PR TITLE
#155 Add liveness and readiness probe

### DIFF
--- a/utilities/cloudharness_utilities/application-templates/base/api/openapi.yaml
+++ b/utilities/cloudharness_utilities/application-templates/base/api/openapi.yaml
@@ -10,7 +10,8 @@ info:
 
 tags:
   - name: test
-
+  - name: live
+  - name: ready
 paths:
   /ping:
     get:
@@ -27,8 +28,36 @@ paths:
             application/json:
               schema:
                 type: string
-
-
+  /live:
+    get:
+      summary: Test if application is healthy
+      operationId: live
+      tags:
+        - live
+      responses:
+        "500":
+          description: Application is not healthy
+        "200":
+          description: Healthy
+          content:
+            application/json:
+              schema:
+                type: string
+  /ready:
+    get:
+      summary: Test if application is ready to take requests
+      operationId: ready
+      tags:
+        - ready
+      responses:
+        "500":
+          description: Application is not ready yet
+        "200":
+          description: Ready
+          content:
+            application/json:
+              schema:
+                type: string
 servers:
   - url: /api
 components:

--- a/utilities/cloudharness_utilities/application-templates/base/deploy/values.yaml
+++ b/utilities/cloudharness_utilities/application-templates/base/deploy/values.yaml
@@ -7,6 +7,10 @@ harness:
   deployment:
     auto: true
     port: 8080
+  livenessProbe:
+    path: /api/live
+  readinessProbe:
+    path: /api/ready
   dependencies:
     build:
       - cloudharness-base

--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-deployments.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-deployments.yaml
@@ -47,6 +47,22 @@ spec:
               key: {{ print $secret.key }}
             {{- end }}
           {{- end }}
+{{ if .app.harness.livenessProbe }}
+        livenessProbe:
+          httpGet:
+            path: {{ .app.harness.livenessProbe.path }}
+            port: {{ .app.harness.deployment.port | default 8080 }}
+          periodSeconds: {{ .app.harness.livenessProbe.periodSeconds | default 10 }}
+          initialDelaySeconds: {{ .app.harness.livenessProbe.initialDelaySeconds | default 0 }}
+{{ end }}
+{{ if .app.harness.readinessProbe }}
+        readinessProbe:
+          httpGet:
+            path: {{ .app.harness.readinessProbe.path }}
+            port: {{ .app.harness.deployment.port | default 8080 }}
+          periodSeconds: {{ .app.harness.livenessProbe.periodSeconds | default 10 }}
+          initialDelaySeconds: {{ .app.harness.readinessProbe.initialDelaySeconds | default 0 }}
+{{ end }}
         ports:
           - containerPort: {{ .app.harness.deployment.port | default 8080 }}
         resources:


### PR DESCRIPTION
livenessProbe and readinessProbe are optional for the application user.
If either of them is specified, a httpGet probe is defined and the user must specify a path for it.
Optionally, she can also specify periodSeconds or initialDelaySeconds to further adjust the probes to the characteristic of the app or environment.

**Manual testing**
* Create application with `harness-application dbapp -t webapp -t db-postgres`
* Choose different configuration for liveness and readiness configuration & test if they are reflected in K8s deployment after helm upgrade