### PR TITLE
Optional tagging on stage/production

### DIFF
--- a/utilities/cloudharness_utilities/deployment-configuration/codefresh-template-prod.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/codefresh-template-prod.yaml
@@ -67,6 +67,10 @@ steps:
     stage: publish
     steps:
       REPLACE_ME
+    when:
+      condition:
+        all:
+          whenVarExists: 'includes("${{DEPLOYMENT_PUBLISH_TAG}}", "{{DEPLOYMENT_PUBLISH_TAG}}") == false'
   git-tag:
     title: Performing git tagging
     stage: publish
@@ -78,3 +82,8 @@ steps:
       - REPLACEMENT=${PROTOCOL}${{REPO_TOKEN}}@
       - git remote set-url origin ${ORIGIN/$PROTOCOL/$REPLACEMENT}
       - git push origin --tags
+    when:
+      condition:
+        all:
+          whenVarExists: 'includes("${{DEPLOYMENT_PUBLISH_TAG}}", "{{DEPLOYMENT_PUBLISH_TAG}}") == false'
+


### PR DESCRIPTION
With this change when DEPLOYMENT_PUBLISH_TAG is not defined on production pipeline we don't do the registry and git tagging