### PR TITLE
#186 Don't require TLS in Keycloak if TLS is deactivated

### DIFF
--- a/applications/accounts/deploy/resources/realm.json
+++ b/applications/accounts/deploy/resources/realm.json
@@ -2,7 +2,7 @@
         "id": {{ .Values.namespace | quote }},
         "realm": {{ .Values.namespace | quote }},
         "enabled": true,
-        "sslRequired": "external",
+        "sslRequired": {{ ternary "none" "external" (not .Values.tls) | quote }},
         "loginTheme": "keycloak",
         "accountTheme": "keycloak",
         "adminTheme": "keycloak",


### PR DESCRIPTION
**Manual testing with minikube:**
* Delete existing cluster
* Start new cluster
* Run `harness-deployment . -l -b -dtls` and install helm chart
* Check in Keycloak UI if ssl required is set to "none"

Repeat procedure but without "-dtls" flag and check if ssl required is set to "external requests".

**Important to know:**
When I enabled/disabled -dtls on an existing cluster, changes won't be reflected, since the realm.json is only imported at startup of accounts pod and only if it wasn't already imported. While one can manually delete keycloak realm and then restart the accounts pod, the tls option is used in many different templates and on first sight it seems that e.g. ingress controller must be restarted as well. **This is not done automatically after deploying the modified helm chart!**
For now, a fresh deployment is required so that a user can be sure that his changes to realm.json were applied.