### PR TITLE
#190 refactor auth api

### DIFF
--- a/libraries/cloudharness-common/cloudharness/applications.py
+++ b/libraries/cloudharness-common/cloudharness/applications.py
@@ -21,7 +21,7 @@ class ApplicationConfiguration:
 
     def __getitem__(self, key_or_path):
         item = self.conf[key_or_path]
-        if (isinstance(item, ConfigObject) or isinstance(item, dict)) and item['harness']:
+        if (isinstance(item, ConfigObject) or isinstance(item, dict)) and 'harness' in item and item['harness']:
             item = ApplicationConfiguration(item)
         return item
 


### PR DESCRIPTION
This refactoring improves clarity in auth initialization code and reduces the calls to keycloak by caching the public key

Closes #190 