### PR TITLE
Feature/164 application naming

### DIFF
--- a/utilities/cloudharness_utilities/openapi.py
+++ b/utilities/cloudharness_utilities/openapi.py
@@ -7,7 +7,7 @@ import json
 import glob
 import urllib.request
 from cloudharness_utilities import HERE
-from cloudharness_utilities.utils import copymergedir, replaceindir, movedircontent, replace_in_file
+from cloudharness_utilities.utils import copymergedir, replaceindir, movedircontent, replace_in_file, to_python_module
 import logging
 
 CODEGEN = os.path.join(HERE, 'bin', 'openapi-generator-cli.jar')
@@ -17,23 +17,21 @@ LIB_NAME = 'cloudharness_cli'
 OPENAPI_GEN_URL = 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.0.0/openapi-generator-cli-5.0.0.jar'
 
 
-
 def generate_server(app_path):
     get_dependencies()
     openapi_dir = os.path.join(app_path, 'api')
     openapi_file = glob.glob(os.path.join(openapi_dir, '*.yaml'))[0]
     out_name = f"backend" if not os.path.exists(f"{app_path}/server") else f"server"
-    out_path=f"{app_path}/{out_name}"
+    out_path = f"{app_path}/{out_name}"
     command = f"java -jar {CODEGEN} generate -i {openapi_file} -g python-flask -o {out_path} -c {openapi_dir}/config.json"
     os.system(command)
-
 
 
 def generate_python_client(module, openapi_file, client_src_path, lib_name=LIB_NAME):
     get_dependencies()
     config_path = os.path.join(os.path.dirname(openapi_file), 'config.json')
 
-    module = module.replace('-', '_')
+    module = to_python_module(module)
     with open(config_path, 'w') as f:
         f.write(json.dumps(dict(packageName=f"{lib_name}.{module}")))
     command = f"java -jar {CODEGEN} generate " \
@@ -42,6 +40,7 @@ def generate_python_client(module, openapi_file, client_src_path, lib_name=LIB_N
               f"-o {client_src_path}/tmp-{module} " \
               f"-c {config_path}"
     os.system(command)
+
 
 def generate_ts_client(openapi_file):
     config_path = os.path.join(os.path.dirname(openapi_file), 'config.json')

--- a/utilities/harness-application
+++ b/utilities/harness-application
@@ -3,12 +3,17 @@
 import sys
 import os
 import shutil
+import re
 
 from cloudharness_utilities import HERE
 from cloudharness_utilities.constants import APPLICATION_TEMPLATE_PATH
 import cloudharness_utilities.openapi
 from cloudharness_utilities.openapi import generate_server, APPLICATIONS_SRC_PATH, generate_ts_client
-from cloudharness_utilities.utils import merge_configuration_directories, replaceindir, replace_in_file, to_python_module
+from cloudharness_utilities.utils import merge_configuration_directories, replaceindir, replace_in_file, \
+    to_python_module
+
+# Only allow lowercased alphabetical characters separated by "-".
+name_pattern = re.compile("[a-z]+((-)?[a-z])?")
 
 PLACEHOLDER = '__APP_NAME__'
 
@@ -34,26 +39,29 @@ if __name__ == "__main__":
     if unknown:
         print('There are unknown args. Make sure to call the script with the accepted args. Try --help')
         print(f'unknown: {unknown}')
-    else:
-        app_path = os.path.join(APPLICATIONS_SRC_PATH, args.name)
+        exit(1)
 
-        for template_name in args.templates:
-            if template_name == 'server':
-                generate_server(app_path)
+    try:
+        match = name_pattern.match(args.name)
+        if not match:
+            print(f"Application name did not match regular expression: {name_pattern.pattern}")
+            exit(1)
+    except re.error:
+        print("Invalid regex")
+        exit(1)
 
-            for base_path in (HERE, os.getcwd()):
-                template_path = os.path.join(base_path, APPLICATION_TEMPLATE_PATH, template_name)
-                if os.path.exists(template_path):
-                    merge_configuration_directories(template_path, app_path)
+    app_path = os.path.join(APPLICATIONS_SRC_PATH, args.name)
+    for template_name in args.templates:
+        if template_name == 'server':
+            generate_server(app_path)
 
-            replace_in_file(os.path.join(app_path, 'api/config.json'), PLACEHOLDER, to_python_module(args.name))
-        replaceindir(app_path, PLACEHOLDER, args.name)
-        if 'webapp' in args.templates:
-            os.remove(os.path.join(app_path, 'backend', 'Dockerfile'))
-            generate_ts_client(openapi_file=os.path.join(app_path, 'api/openapi.yaml'))
+        for base_path in (HERE, os.getcwd()):
+            template_path = os.path.join(base_path, APPLICATION_TEMPLATE_PATH, template_name)
+            if os.path.exists(template_path):
+                merge_configuration_directories(template_path, app_path)
 
-
-
-
-
-
+        replace_in_file(os.path.join(app_path, 'api/config.json'), PLACEHOLDER, to_python_module(args.name))
+    replaceindir(app_path, PLACEHOLDER, args.name)
+    if 'webapp' in args.templates:
+        os.remove(os.path.join(app_path, 'backend', 'Dockerfile'))
+        generate_ts_client(openapi_file=os.path.join(app_path, 'api/openapi.yaml'))

--- a/utilities/harness-application
+++ b/utilities/harness-application
@@ -8,7 +8,7 @@ from cloudharness_utilities import HERE
 from cloudharness_utilities.constants import APPLICATION_TEMPLATE_PATH
 import cloudharness_utilities.openapi
 from cloudharness_utilities.openapi import generate_server, APPLICATIONS_SRC_PATH, generate_ts_client
-from cloudharness_utilities.utils import merge_configuration_directories, replaceindir, replace_in_file
+from cloudharness_utilities.utils import merge_configuration_directories, replaceindir, replace_in_file, to_python_module
 
 PLACEHOLDER = '__APP_NAME__'
 
@@ -37,18 +37,16 @@ if __name__ == "__main__":
     else:
         app_path = os.path.join(APPLICATIONS_SRC_PATH, args.name)
 
-
         for template_name in args.templates:
             if template_name == 'server':
                 generate_server(app_path)
 
             for base_path in (HERE, os.getcwd()):
-
                 template_path = os.path.join(base_path, APPLICATION_TEMPLATE_PATH, template_name)
                 if os.path.exists(template_path):
                     merge_configuration_directories(template_path, app_path)
 
-            replace_in_file(os.path.join(app_path, 'api/config.json'), PLACEHOLDER, args.name.replace('-', '_'))
+            replace_in_file(os.path.join(app_path, 'api/config.json'), PLACEHOLDER, to_python_module(args.name))
         replaceindir(app_path, PLACEHOLDER, args.name)
         if 'webapp' in args.templates:
             os.remove(os.path.join(app_path, 'backend', 'Dockerfile'))

--- a/utilities/harness-application
+++ b/utilities/harness-application
@@ -44,7 +44,8 @@ if __name__ == "__main__":
     try:
         match = name_pattern.match(args.name)
         if not match:
-            print(f"Application name did not match regular expression: {name_pattern.pattern}")
+            print("Invalid application name")
+            print(f"Application name must start and end with lowercased alphabetical characters and may contain '-' as separator. Used expression: '{name_pattern.pattern}'")
             exit(1)
     except re.error:
         print("Invalid regex")


### PR DESCRIPTION
**Proposal:** Application name must start and end with lowercased alphabetical character and may contain "-" as separator.


Would suggest to use a strict naming pattern. This way we avoid complexity and problems caused by different technologies requiring different patterns (K8s vs Python). The suggested pattern works good with K8s and for Python we  modify it in the background.

@filippomc @zsinnema  what do you think?

