### PR TITLE
#317 chore: remove subpart from the configmap mount 

### DIFF
--- a/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-deployments.yaml
+++ b/utilities/cloudharness_utilities/deployment-configuration/helm/templates/auto-deployments.yaml
@@ -101,8 +101,8 @@ spec:
 
         volumeMounts:
           - name: cloudharness-allvalues
-            mountPath: /opt/cloudharness/resources/allvalues.yaml
-            subPath: allvalues.yaml
+            mountPath: /opt/cloudharness/resources
+            readOnly: true
           {{- if .app.harness.deployment.volume }}
           - name: {{ .app.harness.deployment.volume.name }}
             mountPath: {{ .app.harness.deployment.volume.mountpath }}


### PR DESCRIPTION
 remove subpart from the configmap mount to enable auto refresh, see https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically