### PR TITLE
#356 ssh:default support for docker buildkit builds to support cloning of private git repos

### DIFF
--- a/utilities/cloudharness_utilities/skaffold.py
+++ b/utilities/cloudharness_utilities/skaffold.py
@@ -36,7 +36,8 @@ def create_skaffold_configuration(root_paths, helm_values, output_path='.', mana
                     'REGISTRY': helm_values["registry"]["name"],
                     'TAG': helm_values["tag"],
                     'NOCACHE': str(time.time())
-                }
+                },
+                'ssh': 'default'
             }
         }
         if requirements:


### PR DESCRIPTION
For buildkit set `ssh:default` to allow private repo to be cloned in a docker file
see https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds for more info