### PR TITLE
#362 chore: upgrade Keycloak to 16.1.0

### DIFF
--- a/applications/accounts/Dockerfile
+++ b/applications/accounts/Dockerfile
@@ -1,3 +1,3 @@
-FROM quay.io/keycloak/keycloak:11.0.2
+FROM quay.io/keycloak/keycloak:16.1.0
 # Customize keycloak look
 COPY themes/custom /opt/jboss/keycloak/themes/custom


### PR DESCRIPTION
I've tested the new CH version with MNP and everything seems to work as it should.