### PR TITLE
#401 implement ch middleware for Flask and Django to set/get the ch application state. Refactored ch kc authentication to disconnect it from Flask

### DIFF
--- a/docs/applications/development/backend-development.md
+++ b/docs/applications/development/backend-development.md
@@ -68,7 +68,43 @@ def info_from_bearerAuth(token):
 
 #### Using the AuthClient
 
-TODO
+The Cloudharness AuthClient is a handy wrapper for the Keycloak REST API.
+This wrapper class can be used to retrieve the current user of the http(s) request
+or to retrieve the Keycloak groups with all users etc.
+
+All functions of the AuthClient class are wrapped by the `with_refreshtoken` decorator
+to auto refresh the token in case the token is expired. There is no need to manually
+refresh the token.
+
+`AuthClient` uses the `admin_api` account to log in into the Keycloak admin REST api
+the password is stored in the `accounts` secret and is retrieve using the Cloudharness
+`get_secret` function (imported from `cloudharness.utils.secrets`)
+
+<br/>
+
+For more information about the usage of the `AuthClient` see the Python doc strings
+
+<br/>
+
+**Important note:**
+
+it is mandatory that the application deployment has a hard dependency to the 
+`accounts` application. This dependency will mount the accounts secret to the pods.
+
+<br/>
+
+Examples:
+```python
+from cloudharness.auth.keycloak import AuthClient
+
+ac = AuthClient()
+
+def example1():
+  current_user = ac.get_current_user()
+
+def exampl2():
+  all_groups = ac.get_groups(with_members=True)
+```
 
 
 ### Run workflows

--- a/libraries/cloudharness-common/README.md
+++ b/libraries/cloudharness-common/README.md
@@ -26,3 +26,22 @@ Install with setuptools from sources
 cd libraries/cloudharness
 pip install .
 ```
+
+## Django Middleware
+
+This library also contains a Django Middleware module needed to use the Cloudharness AuthClient.
+To activate this middleware add `cloudharness.middleware.django.CloudharnessMiddleware` to your
+Django middleware classes.
+
+E.g. in Django settings.py
+```
+...
+
+MIDDLEWARE = [
+    ...
+    'cloudharness.middleware.django.CloudharnessMiddleware',
+    ...
+]
+
+...
+```

--- a/libraries/cloudharness-common/README.md
+++ b/libraries/cloudharness-common/README.md
@@ -27,9 +27,24 @@ cd libraries/cloudharness
 pip install .
 ```
 
+
+# Middleware
+
+This library also contains a Flask and Django Middleware module which is needed 
+for using the Cloudharness AuthClient package.
+These middlewares use the request header `Authorization` to set the `ch_authentication_token`
+contextvar in `cloudharness.middleware.__init__.py`. The AuthClient uses the authentication token
+to validate the request and retrieve the Keycloak user
+
+## Flask Middleware
+
+The Flask middleware is activated in the `init_flask` and will be executed on each request. There
+is no need to manually activate this middleware.
+
+
 ## Django Middleware
 
-This library also contains a Django Middleware module needed to use the Cloudharness AuthClient.
+This library also contains a Django Middleware module which is needed to use the Cloudharness AuthClient.
 To activate this middleware add `cloudharness.middleware.django.CloudharnessMiddleware` to your
 Django middleware classes.
 

--- a/libraries/cloudharness-common/cloudharness/middleware/__init__.py
+++ b/libraries/cloudharness-common/cloudharness/middleware/__init__.py
@@ -6,4 +6,4 @@ def set_authentication_token(authentication_token):
     _authentication_token.set(authentication_token)
 
 def get_authentication_token():
-    return _ch_authentication_token.get()
+    return _authentication_token.get()

--- a/libraries/cloudharness-common/cloudharness/middleware/__init__.py
+++ b/libraries/cloudharness-common/cloudharness/middleware/__init__.py
@@ -1,0 +1,12 @@
+from contextvars import ContextVar, copy_context
+
+_middleware = None
+_state = ContextVar("ch_state", default={})
+
+def update_state(state):
+    new_state = _state.get()
+    new_state.update(state)
+    _state.set(new_state)
+
+def get_state():
+    return _state.get()

--- a/libraries/cloudharness-common/cloudharness/middleware/__init__.py
+++ b/libraries/cloudharness-common/cloudharness/middleware/__init__.py
@@ -1,12 +1,9 @@
 from contextvars import ContextVar, copy_context
 
-_middleware = None
-_state = ContextVar("ch_state", default={})
+_authentication_token = ContextVar("ch_authentication_token", default=None)
 
-def update_state(state):
-    new_state = _state.get()
-    new_state.update(state)
-    _state.set(new_state)
+def set_authentication_token(authentication_token):
+    _authentication_token.set(authentication_token)
 
-def get_state():
-    return _state.get()
+def get_authentication_token():
+    return _ch_authentication_token.get()

--- a/libraries/cloudharness-common/cloudharness/middleware/django.py
+++ b/libraries/cloudharness-common/cloudharness/middleware/django.py
@@ -1,0 +1,26 @@
+from django.conf import settings
+from cloudharness.middleware import update_state
+
+
+class CloudharnessMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # One-time configuration and initialization.
+
+    def __call__(self, request):
+        # Code to be executed for each request before
+        # the view (and later middleware) are called.
+
+        bearer = request.headers.get('Authorization')
+        env = "production" if not settings.DEBUG else "development"
+        update_state({
+            "bearer": bearer,
+            "env": env,
+        })
+
+        response = self.get_response(request)
+
+        # Code to be executed for each request/response after
+        # the view is called.
+
+        return response

--- a/libraries/cloudharness-common/cloudharness/middleware/django.py
+++ b/libraries/cloudharness-common/cloudharness/middleware/django.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from cloudharness.middleware import update_state
+from cloudharness.middleware import set_authentication_token
 
 
 class CloudharnessMiddleware:
@@ -11,12 +11,9 @@ class CloudharnessMiddleware:
         # Code to be executed for each request before
         # the view (and later middleware) are called.
 
-        bearer = request.headers.get('Authorization')
-        env = "production" if not settings.DEBUG else "development"
-        update_state({
-            "bearer": bearer,
-            "env": env,
-        })
+        # retrieve the bearer token from the header
+        # and save it for use in the AuthClient
+        set_authentication_token(request.headers.get('Authorization'))
 
         response = self.get_response(request)
 

--- a/libraries/cloudharness-common/cloudharness/middleware/flask.py
+++ b/libraries/cloudharness-common/cloudharness/middleware/flask.py
@@ -1,6 +1,5 @@
-from flask import current_app
 from werkzeug.wrappers import Request, Response, ResponseStream
-from cloudharness.middleware import update_state
+from cloudharness.middleware import set_authentication_token
 
 
 class middleware():
@@ -13,14 +12,9 @@ class middleware():
 
     def __call__(self, environ, start_response):
         request = Request(environ)
-        bearer = request.headers.get("Authorization")
-        try:
-            env = current_app.config.get("ENV")
-        except:
-            env = "production"
-        update_state({
-            "bearer": bearer,
-            "env": env,
-        })
+
+        # retrieve the bearer token from the header
+        # and save it for use in the AuthClient
+        set_authentication_token(request.headers.get('Authorization'))
 
         return self.app(environ, start_response)

--- a/libraries/cloudharness-common/cloudharness/middleware/flask.py
+++ b/libraries/cloudharness-common/cloudharness/middleware/flask.py
@@ -1,0 +1,26 @@
+from flask import current_app
+from werkzeug.wrappers import Request, Response, ResponseStream
+from cloudharness.middleware import update_state
+
+
+class middleware():
+    '''
+    CloudHarness WSGI middleware
+    '''
+
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        request = Request(environ)
+        bearer = request.headers.get("Authorization")
+        try:
+            env = current_app.config.get("ENV")
+        except:
+            env = "production"
+        update_state({
+            "bearer": bearer,
+            "env": env,
+        })
+
+        return self.app(environ, start_response)

--- a/libraries/cloudharness-common/cloudharness/utils/server.py
+++ b/libraries/cloudharness-common/cloudharness/utils/server.py
@@ -9,6 +9,7 @@ import six
 
 from cloudharness import log as logging
 from cloudharness.applications import get_current_configuration
+from cloudharness.middleware.flask import middleware
 
 app = None
 
@@ -81,6 +82,8 @@ def init_flask(title='CH service API', init_app_fn=None, webapp=False, json_enco
     if obj_config:
         app.config.from_object(obj_config)
     app.json_encoder = json_encoder
+    # activate the CH middleware
+    app.wsgi_app = middleware(app.wsgi_app)
 
     with app.app_context():
         # setup logging

--- a/libraries/cloudharness-common/tests/test_middleware.py
+++ b/libraries/cloudharness-common/tests/test_middleware.py
@@ -1,0 +1,33 @@
+
+from unittest import mock
+
+from cloudharness.auth.keycloak import AuthClient
+from cloudharness.middleware import get_authentication_token, set_authentication_token
+
+TEST_USER_ID = "1234567890"
+TEST_AUTHENTICATION_TOKEN = f"Bearer {TEST_USER_ID}"
+
+
+def new_init(self):
+    pass
+
+def new_decode_token(token):
+    # if everything went fine then the token contains the value of sub
+    # let's return it
+    return {
+        'sub': token
+    }
+
+def test_setting_and_getting_auth_token():
+    set_authentication_token(TEST_AUTHENTICATION_TOKEN)
+    assert get_authentication_token() == TEST_AUTHENTICATION_TOKEN
+
+def test_decoding():
+    mocker = AuthClient
+    mocker.decode_token = new_decode_token
+    mocker.__init__ = new_init
+
+    set_authentication_token(TEST_AUTHENTICATION_TOKEN)
+    ac = AuthClient()
+    cur_user_id = ac._get_keycloak_user_id()
+    assert cur_user_id == TEST_USER_ID


### PR DESCRIPTION
Remove Flask dependency from CH Keycloak AuthClient

Closes #401 

Implemented solution:  implement ch middleware for Flask and Django to set/get the ch application state. Refactored ch kc authentication to disconnect it from Flask

How to test: ...

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [ ] From the issue and the current pr it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automatic test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x ] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This pr and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This pr and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this pr are out of the current documentation scope
