### PR TITLE
#384 fix: mount secret also on accounts pod

### DIFF
--- a/tools/cloudharness_utilities/deployment-configuration/helm/templates/auto-deployments.yaml
+++ b/tools/cloudharness_utilities/deployment-configuration/helm/templates/auto-deployments.yaml
@@ -105,7 +105,7 @@ spec:
           - name: cloudharness-allvalues
             mountPath: /opt/cloudharness/resources
             readOnly: true
-          {{- if has  "accounts" .app.harness.dependencies.hard }}
+          {{- if or (has  "accounts" .app.harness.dependencies.hard) (eq .app.harness.name "accounts") }}
           - name: cloudharness-kc-accounts
             mountPath: /opt/cloudharness/resources/auth
             readOnly: true
@@ -131,7 +131,7 @@ spec:
         - name: cloudharness-allvalues
           configMap:
             name: cloudharness-allvalues
-        {{- if has  "accounts" .app.harness.dependencies.hard }}
+        {{- if or (has  "accounts" .app.harness.dependencies.hard) (eq .app.harness.name "accounts") }}
         - name: cloudharness-kc-accounts
           secret:
             secretName: accounts


### PR DESCRIPTION
Fixes #384

Implemented solution: the secret must be applied not only on deployments with a hard dependency on accounts, but also on accounts itself, as it is used to initialize the user in the first run.

How to test this PR: run a deployment and verify that inside accounts the path /opt/cloudharness/resources/auth/api_user_password exists

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
