### PR TITLE
#449 feature: add keycloak group support to AuthClient

### DIFF
--- a/libraries/cloudharness-common/cloudharness/auth/keycloak.py
+++ b/libraries/cloudharness-common/cloudharness/auth/keycloak.py
@@ -305,7 +305,7 @@ class AuthClient():
         :return: GroupRepresentation
         """
         admin_client = self.get_admin_client()
-        return admin_client.update_group(payload, group_id, payload)
+        return admin_client.update_group(group_id, payload)
 
     @with_refreshtoken
     def group_user_add(self, user_id, group_id):

--- a/libraries/cloudharness-common/cloudharness/auth/keycloak.py
+++ b/libraries/cloudharness-common/cloudharness/auth/keycloak.py
@@ -171,7 +171,7 @@ class AuthClient():
         Return the KC client
 
         ClientRepresentation
-        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_clientrepresentation
+        https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_clientrepresentation
 
         :param client_name: Name of the client to retrieve
         :return: ClientRepresentation or False when not found
@@ -244,7 +244,7 @@ class AuthClient():
         Return the group in the application realm
 
         GroupRepresentation
-        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_grouprepresentation
+        https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_grouprepresentation
 
         :param with_members: If set the members (users) of the group are added to the group. Defaults to False
         :return: GroupRepresentation + UserRepresentation
@@ -267,7 +267,7 @@ class AuthClient():
         Return a list of all groups in the application realm
 
         GroupRepresentation
-        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_grouprepresentation
+        https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_grouprepresentation
 
         :param with_members: If set the members (users) of the group(s) are added to the group. Defaults to False
         :return: List(GroupRepresentation)
@@ -279,17 +279,70 @@ class AuthClient():
         return groups
 
     @with_refreshtoken
+    def create_group(self, payload, parent=None):
+        """
+        Create a group in the application realm
+
+        GroupRepresentation
+        https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_grouprepresentation
+
+        :param payload: the payload to create the group
+        :return: GroupRepresentation
+        """
+        admin_client = self.get_admin_client()
+        return admin_client.create_group(payload, parent, skip_exists=True)
+
+    @with_refreshtoken
+    def update_group(self, group_id, payload):
+        """
+        Updates the group identified by the given group_id in the application realm
+
+        GroupRepresentation
+        https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_grouprepresentation
+
+        :param group_id: the id of the group to update
+        :param payload: the payload to create the group
+        :return: GroupRepresentation
+        """
+        admin_client = self.get_admin_client()
+        return admin_client.update_group(payload, group_id, payload)
+
+    @with_refreshtoken
+    def group_user_add(self, user_id, group_id):
+        """
+        Add user to group (user_id and group_id)
+
+        :param user_id:  id of user
+        :param group_id:  id of group to add to
+        :return: Keycloak server response
+        """
+        admin_client = self.get_admin_client()
+        return admin_client.group_user_add(user_id, group_id)
+
+    @with_refreshtoken
+    def group_user_remove(self, user_id, group_id):
+        """
+        Remove user from group (user_id and group_id)
+
+        :param user_id:  id of user
+        :param group_id:  id of group to remove from
+        :return: Keycloak server response
+        """
+        admin_client = self.get_admin_client()
+        return admin_client.group_user_remove(user_id, group_id)
+
+    @with_refreshtoken
     def get_users(self, query=None):
         """
         Return a list of all users in the application realm
 
         UserRepresentation
-        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_userrepresentation
+        https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_userrepresentation
 
         GroupRepresentation
-        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_grouprepresentation
+        https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_grouprepresentation
 
-        :param query: query filtering the users see https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_users_resource
+        :param query: query filtering the users see https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_users_resource
         :return: List(UserRepresentation + GroupRepresentation)
         """
         admin_client = self.get_admin_client()
@@ -311,10 +364,10 @@ class AuthClient():
         :param user_id: User id
 
         UserRepresentation
-        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_userrepresentation
+        https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_userrepresentation
 
         GroupRepresentation
-        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_grouprepresentation
+        https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_grouprepresentation
 
         :return: UserRepresentation + GroupRepresentation
         """
@@ -330,10 +383,10 @@ class AuthClient():
         Get the current user including the user groups
 
         UserRepresentation
-        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_userrepresentation
+        https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_userrepresentation
 
         GroupRepresentation
-        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_grouprepresentation
+        https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_grouprepresentation
 
         :return: UserRepresentation + GroupRepresentation
         """
@@ -348,7 +401,7 @@ class AuthClient():
         :param user_id: User id
 
         RoleRepresentation
-        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_rolerepresentation
+        https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_rolerepresentation
 
         :return: (array RoleRepresentation)
         """
@@ -360,7 +413,7 @@ class AuthClient():
         Get the current user realm roles within the current realm
 
         RoleRepresentation
-        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_rolerepresentation
+        https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_rolerepresentation
 
         :return: (array RoleRepresentation)
         """

--- a/libraries/cloudharness-common/cloudharness/auth/keycloak.py
+++ b/libraries/cloudharness-common/cloudharness/auth/keycloak.py
@@ -279,21 +279,27 @@ class AuthClient():
         return groups
 
     @with_refreshtoken
-    def create_group(self, payload, parent=None):
+    def create_group(self, name: str, parent: str=None):
         """
         Create a group in the application realm
 
         GroupRepresentation
         https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_grouprepresentation
 
-        :param payload: the payload to create the group
+        :param name: the name of the group
+        :param parent: parent group's id. Required to create a sub-group.
         :return: GroupRepresentation
         """
         admin_client = self.get_admin_client()
-        return admin_client.create_group(payload, parent, skip_exists=True)
+        return admin_client.create_group(
+            payload={
+                "name": name,
+            },
+            parent=parent,
+            skip_exists=True)
 
     @with_refreshtoken
-    def update_group(self, group_id, payload):
+    def update_group(self, group_id: str, name: str):
         """
         Updates the group identified by the given group_id in the application realm
 
@@ -301,11 +307,15 @@ class AuthClient():
         https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_grouprepresentation
 
         :param group_id: the id of the group to update
-        :param payload: the payload to create the group
+        :param name: the new name of the group
         :return: GroupRepresentation
         """
         admin_client = self.get_admin_client()
-        return admin_client.update_group(group_id, payload)
+        return admin_client.update_group(
+            group_id=group_id,
+            payload={
+                "name": name
+            })
 
     @with_refreshtoken
     def group_user_add(self, user_id, group_id):


### PR DESCRIPTION
Closes #449 

Implemented solution: add the create/update groups methods and add/remove user from groups methods to AuthClient

How to test this PR: 
```
from cloudharness.auth import AuthClient
ac = AuthClient()
ac.create_group({"name":"New Group"})
```

then check in Keycloak groups if the New Group was created

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [x] The documentation has been updated to match the current changes (documentation is in the code)
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
