### PR TITLE
#427 Fix codefresh files

### DIFF
--- a/tools/cloudharness_utilities/codefresh.py
+++ b/tools/cloudharness_utilities/codefresh.py
@@ -76,10 +76,10 @@ def create_codefresh_deployment_scripts(root_paths, env, include=(), exclude=(),
             codefresh = dict_merge(codefresh, tpl)
 
         def codefresh_build_step_from_base_path(base_path, build_step, fixed_context=None, include=include):
-            abs_base_path = os.path.join(os.getcwd(), base_path)
-            for dockerfile_path in find_dockerfiles_paths(abs_base_path):
+            
+            for dockerfile_path in find_dockerfiles_paths(base_path):
                 app_relative_to_root = os.path.relpath(dockerfile_path, '.')
-                app_relative_to_base = os.path.relpath(dockerfile_path, abs_base_path)
+                app_relative_to_base = os.path.relpath(dockerfile_path, base_path)
                 app_name = app_name_from_path(app_relative_to_base)
                 if include and not any(
                         f"/{inc}/" in dockerfile_path or dockerfile_path.endswith(f"/{inc}") for inc in include):
@@ -92,7 +92,7 @@ def create_codefresh_deployment_scripts(root_paths, env, include=(), exclude=(),
                         app_name=app_name,
                         app_context_path=os.path.relpath(fixed_context, '.') if fixed_context else app_relative_to_root,
                         dockerfile_path=os.path.join(
-                            os.path.relpath(dockerfile_path, os.getcwd()) if fixed_context else '',
+                            os.path.relpath(dockerfile_path, root_path) if fixed_context else '',
                             "Dockerfile"),
                         base_name=base_image_name,
                         helm_values=values_manual_deploy

--- a/tools/tests/test_codefresh.py
+++ b/tools/tests/test_codefresh.py
@@ -56,8 +56,7 @@ def test_create_codefresh_configuration():
     assert os.path.samefile(step['working_directory'], CLOUDHARNESS_ROOT)
 
     step = steps["cloudharness-base"]
-    assert os.path.samefile(step['dockerfile'], os.path.join(
-        BUILD_MERGE_DIR, BASE_IMAGES_PATH, "cloudharness-base", "Dockerfile"))
+    assert os.path.samefile(step['dockerfile'], os.path.join(BASE_IMAGES_PATH, "cloudharness-base", "Dockerfile"))
     assert step['working_directory'] == BUILD_MERGE_DIR
 
     steps = l1_steps["build_static_images"]["steps"]

--- a/tools/tests/test_codefresh.py
+++ b/tools/tests/test_codefresh.py
@@ -51,13 +51,15 @@ def test_create_codefresh_configuration():
     assert "cloudharness-frontend-build" in steps
 
     step = steps["cloudharness-frontend-build"]
-    assert  os.path.samefile(step['dockerfile'], os.path.join(CLOUDHARNESS_ROOT,
-        BASE_IMAGES_PATH, "cloudharness-frontend-build", "Dockerfile"))
     assert os.path.samefile(step['working_directory'], CLOUDHARNESS_ROOT)
+    assert  os.path.samefile(os.path.join(step['working_directory'], step['dockerfile']), os.path.join(CLOUDHARNESS_ROOT,
+        BASE_IMAGES_PATH, "cloudharness-frontend-build", "Dockerfile"))
+    
 
     step = steps["cloudharness-base"]
-    assert os.path.samefile(step['dockerfile'], os.path.join(BASE_IMAGES_PATH, "cloudharness-base", "Dockerfile"))
     assert step['working_directory'] == BUILD_MERGE_DIR
+    assert os.path.samefile(os.path.join(step['working_directory'], step['dockerfile']), os.path.join(step['working_directory'], BASE_IMAGES_PATH, "cloudharness-base", "Dockerfile"))
+    
 
     steps = l1_steps["build_static_images"]["steps"]
     assert len(steps) == 2


### PR DESCRIPTION
Fixes #427 issue with codefresh paths

Implemented solution: fixed the relative paths for build context

How to test this PR: run `harness-deployment ... -e dev` and run generated build spec on codefresh.

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [x] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
