### PR TITLE
#469 feature: enable application volume to be shared across multiple different deployments

### DIFF
--- a/docs/applications/README.md
+++ b/docs/applications/README.md
@@ -95,6 +95,7 @@ The most important configuration entries are the following:
   - `deployment`: creates a deployment
     - `auto`: if true, creates the deployment automatically
     - `resources`: define cpu and memory limits
+    - `volume`: application persistent volume
   - `service`:
     - `auto`: if true, creates the service automatically
   - `dependencies`: lists of applications/images this application depends from

--- a/docs/applications/volumes.md
+++ b/docs/applications/volumes.md
@@ -1,0 +1,31 @@
+# Application Volume
+
+Application Volumes are defined at `harness.deployment.volume`.
+At the time of writing this documentation CloudHarness supports only one volume per deployment.
+
+The Application Volume will be mounted in the container at a specific path at **deployment** time.
+
+A Volume can be mounted by one or more pods (shared Volume). Be careful: only one of the deployments
+should create the Volume, the other deployment should only mount it.
+
+This can be established through setting the `auto` attribute (default false) of the Volume object
+auto: true --> auto create the volume and mount
+auto: false --> only mount the volume
+
+Shared volumes are handy when you have e.g. 2 deployments for one app: frontend & backend deployment
+in such a case it could be helpfull that the frontend can access files stored by the backend.
+E.g. user uploaded media files
+
+**Example**
+
+```yaml
+harness:
+  ...
+  deployment:
+    ...
+    volume:
+      name: myFirstVolume
+      mountpath: /usr/src/app/myvolume
+      auto: true
+      size: 5Gi
+```

--- a/tools/cloudharness_utilities/deployment-configuration/helm/templates/auto-volumes.yaml
+++ b/tools/cloudharness_utilities/deployment-configuration/helm/templates/auto-volumes.yaml
@@ -1,4 +1,5 @@
 {{- define "deploy_utils.pvolume" }}
+{{- if not .app.harness.deployment.volume.auto }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -12,6 +13,7 @@ spec:
   resources:
     requests:
       storage: {{ .app.harness.deployment.volume.size }}
+{{- end }}
 ---
 {{- end }}
 {{- range $app := .Values.apps }}


### PR DESCRIPTION


Closes #469 

Implemented solution: add extra attribute to the deployment.volume object: auto true/false

How to test this PR: create 2 microservices and add the same volume to both with the exception that only one should have auto set to true

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [x] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
