### PR TITLE
#418 Force restart of gatekeeper on conf change

### DIFF
--- a/applications/samples/deploy/values.yaml
+++ b/applications/samples/deploy/values.yaml
@@ -1,6 +1,6 @@
 harness:
   subdomain: samples
-  secured: false
+  secured: true
   sentry: true
   port: 80
   service:
@@ -9,6 +9,13 @@ harness:
   deployment:
     auto: true
     port: 8080
+  uri_role_mapping:
+    - uri: /
+      white-listed: true
+    - uri: /api/ui
+      white-listed: true
+    - uri: /api/error
+      white-listed: true
   env:
     - name: WORKERS
       value: "3"

--- a/tools/cloudharness_utilities/deployment-configuration/helm/templates/auto-gatekeepers.yaml
+++ b/tools/cloudharness_utilities/deployment-configuration/helm/templates/auto-gatekeepers.yaml
@@ -90,6 +90,7 @@ metadata:
   name: "{{ .app.harness.service.name }}-gk"
   labels:
     app: "{{ .app.harness.service.name }}-gk"
+  
 spec:
   replicas: 1
   selector:
@@ -97,6 +98,8 @@ spec:
       app: "{{ .app.harness.service.name }}-gk"
   template:
     metadata:
+      annotations:
+        checksum/config: {{ .app.harness.uri_role_mapping | toString | sha256sum }}
       labels:
         app: "{{ .app.harness.service.name }}-gk"
     spec:


### PR DESCRIPTION
Closes #418 

Implemented solution: added a checksum from the configuration to force pod restart -- see https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments

How to test this PR: The simplest way to test is to make a local deployment from `harness-deployment . -i samples ...` and play with samples/values.yaml to change the configuration

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
