### PR TITLE
#444 implement multiple environments functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ skaffold.yaml
 .pytest_cache
 .overrides
 deployment.yaml
+/deployment-configuration

--- a/docs/build-deploy/environments.md
+++ b/docs/build-deploy/environments.md
@@ -4,6 +4,8 @@ Different deployments often require different configurations.
 For instance, we may want to assign less resources/replicas to a pod deployed locally
 respect to the production build.
 
+## How to set the environment
+
 The environment of the current deployment can ve set with the parameter `--env` (`-e`)
 of `harness-deployment`.
 
@@ -19,9 +21,7 @@ harness-deployment cloud-harness . -e dev
 the following configuration files are potentially loaded (if they exist):
 
 - `deployment-configuration/values-template-dev.yaml`
-- `deployment-configuration/skaffold-template-dev.yaml`
 - `deployment-configuration/codefresh-template-dev.yaml`
-- `deployment-configuration/codefresh-build-template-dev.yaml`
 
 And for each application:
 
@@ -58,3 +58,23 @@ b: 2
 c: 3
 d: 4
 ```
+
+## Multiple environments
+
+Multiple environments can be set by separating different environments with an hyphen, like `-e env1-env2`
+
+For example, by running 
+
+```
+harness-deployment cloud-harness . -e dev-test
+```
+
+We get the following loading order:
+
+```
+values.yaml
+values-dev.yaml
+values-test.yaml
+```
+
+The same principle applies to all templates.

--- a/tools/cloudharness_utilities/codefresh.py
+++ b/tools/cloudharness_utilities/codefresh.py
@@ -1,4 +1,5 @@
 import os
+from re import template
 from .models import HarnessMainConfig
 import oyaml as yaml
 import yaml.representer
@@ -30,87 +31,101 @@ def literal_presenter(dumper, data):
 yaml.add_representer(str, literal_presenter)
 
 
-def create_codefresh_deployment_scripts(root_paths, env, include=(), exclude=(),
+def create_codefresh_deployment_scripts(root_paths, envs=(), include=(), exclude=(),
                                         template_name=CF_TEMPLATE_PATH, base_image_name=None,
-                                        values_manual_deploy: HarnessMainConfig=None, save=True):
+                                        values_manual_deploy: HarnessMainConfig = None, save=True):
     """
     Entry point to create deployment scripts for codefresh: codefresh.yaml and helm chart
     """
-    template_name = f"codefresh-template-{env}.yaml"
-    out_filename = f"codefresh-{env}.yaml"
+
+    out_filename = f"codefresh-{'-'.join(envs)}.yaml"
+
     if include:
-        logging.info('Including the following subpaths to the build: %s.', ', '.join(include))
+        logging.info(
+            'Including the following subpaths to the build: %s.', ', '
+            .join(include)
+        )
 
     if exclude:
-        logging.info('Excluding the following subpaths to the build: %s.', ', '.join(exclude))
+        logging.info(
+            'Excluding the following subpaths to the build: %s.', ', '
+            .join(exclude)
+        )
 
-    codefresh = get_template(os.path.join(DEPLOYMENT_CONFIGURATION_PATH, template_name), True)
-
-    if not codefresh:
-        if template_name != CF_TEMPLATE_PATH:
-            logging.warning("Template file %s not found. Codefresh script not created.", template_name)
-            if os.path.exists(os.path.join(HERE, CF_TEMPLATE_PATH)):
-                logging.info("Loading legacy template %s", CF_TEMPLATE_PATH)
-                codefresh = get_template(os.path.join(HERE, CF_TEMPLATE_PATH), True)
-        return
-    logging.info("Creating codefresh script %s", out_filename)
-
-    if CF_BUILD_STEP_BASE in codefresh['steps']:
-        codefresh['steps'][CF_BUILD_STEP_BASE]['steps'] = {}
-        codefresh['steps'][CF_BUILD_STEP_STATIC]['steps'] = {}
-        codefresh['steps'][CF_BUILD_STEP_PARALLEL]['steps'] = {}
-    if CF_STEP_PUBLISH in codefresh['steps']:
-        codefresh['steps'][CF_STEP_PUBLISH]['steps'] = {}
+    codefresh = {}
 
     for root_path in root_paths:
-        template_path = os.path.join(root_path, DEPLOYMENT_CONFIGURATION_PATH, template_name)
-        if os.path.exists(template_path):
-            tpl = get_template(template_path, True)
-            if CF_BUILD_STEP_BASE in codefresh['steps']:
-                del tpl['steps'][CF_BUILD_STEP_BASE]
-            if CF_BUILD_STEP_STATIC in codefresh['steps']:
-                del tpl['steps'][CF_BUILD_STEP_STATIC]
-            if CF_BUILD_STEP_PARALLEL in codefresh['steps']:
-                del tpl['steps'][CF_BUILD_STEP_PARALLEL]
-            if CF_STEP_PUBLISH in codefresh['steps']:
-                del tpl['steps'][CF_STEP_PUBLISH]
-            codefresh = dict_merge(codefresh, tpl)
+        for e in envs:
+            template_name = f"codefresh-template-{e}.yaml"
+            template_path = os.path.join(
+                root_path, DEPLOYMENT_CONFIGURATION_PATH, template_name)
 
-        def codefresh_build_step_from_base_path(base_path, build_step, fixed_context=None, include=include):
-            
-            for dockerfile_path in find_dockerfiles_paths(base_path):
-                app_relative_to_root = os.path.relpath(dockerfile_path, '.')
-                app_relative_to_base = os.path.relpath(dockerfile_path, base_path)
-                app_name = app_name_from_path(app_relative_to_base)
-                if include and not any(
-                        f"/{inc}/" in dockerfile_path or dockerfile_path.endswith(f"/{inc}") for inc in include):
-                    continue
-                if any(inc in dockerfile_path for inc in (list(exclude) + EXCLUDE_PATHS)):
-                    continue
-                build = None
-                if CF_BUILD_STEP_BASE in codefresh['steps']:
-                    build = codefresh_app_build_spec(
-                        app_name=app_name,
-                        app_context_path=os.path.relpath(fixed_context, '.') if fixed_context else app_relative_to_root,
-                        dockerfile_path=os.path.join(
-                            os.path.relpath(dockerfile_path, root_path) if fixed_context else '',
-                            "Dockerfile"),
-                        base_name=base_image_name,
-                        helm_values=values_manual_deploy
-                    )
-                    codefresh['steps'][build_step]['steps'][app_name] = build
-                if CF_STEP_PUBLISH in codefresh['steps']:
-                    codefresh['steps'][CF_STEP_PUBLISH]['steps']['publish_' + app_name] = codefresh_app_publish_spec(
-                        app_name=app_name,
-                        build_tag=build and build['tag'],
-                        base_name=base_image_name
-                    )
+            if os.path.exists(template_path):
+                logging.info("Codefresh template found: %s", template_path)
+                tpl = get_template(template_path, True)
+                if 'steps' in tpl:
+                    if codefresh and CF_BUILD_STEP_BASE in codefresh['steps']:
+                        del tpl['steps'][CF_BUILD_STEP_BASE]
+                    if codefresh and CF_BUILD_STEP_STATIC in codefresh['steps']:
+                        del tpl['steps'][CF_BUILD_STEP_STATIC]
+                    if codefresh and CF_BUILD_STEP_PARALLEL in codefresh['steps']:
+                        del tpl['steps'][CF_BUILD_STEP_PARALLEL]
+                    if codefresh and CF_STEP_PUBLISH in codefresh['steps']:
+                        del tpl['steps'][CF_STEP_PUBLISH]
+                codefresh = dict_merge(codefresh, tpl)
 
-        codefresh_build_step_from_base_path(os.path.join(root_path, BASE_IMAGES_PATH), CF_BUILD_STEP_BASE,
-                                            fixed_context=os.path.relpath(root_path, os.getcwd()), include=values_manual_deploy[KEY_TASK_IMAGES].keys())
-        codefresh_build_step_from_base_path(os.path.join(root_path, STATIC_IMAGES_PATH), CF_BUILD_STEP_STATIC,
-                                            include=values_manual_deploy[KEY_TASK_IMAGES].keys())
-        codefresh_build_step_from_base_path(os.path.join(root_path, APPS_PATH), CF_BUILD_STEP_PARALLEL)
+
+            def codefresh_build_step_from_base_path(base_path, build_step, fixed_context=None, include=include):
+
+                for dockerfile_path in find_dockerfiles_paths(base_path):
+                    app_relative_to_root = os.path.relpath(
+                        dockerfile_path, '.')
+                    app_relative_to_base = os.path.relpath(
+                        dockerfile_path, base_path)
+                    app_name = app_name_from_path(app_relative_to_base)
+                    if include and not any(
+                            f"/{inc}/" in dockerfile_path or dockerfile_path.endswith(f"/{inc}") for inc in include):
+                        continue
+                    if any(inc in dockerfile_path for inc in (list(exclude) + EXCLUDE_PATHS)):
+                        continue
+                    build = None
+                    if CF_BUILD_STEP_BASE in codefresh['steps']:
+                        build = codefresh_app_build_spec(
+                            app_name=app_name,
+                            app_context_path=os.path.relpath(
+                                fixed_context, '.') if fixed_context else app_relative_to_root,
+                            dockerfile_path=os.path.join(
+                                os.path.relpath(
+                                    dockerfile_path, root_path) if fixed_context else '',
+                                "Dockerfile"),
+                            base_name=base_image_name,
+                            helm_values=values_manual_deploy
+                        )
+
+                        if not type(codefresh['steps'][build_step]['steps']) == dict:
+                            codefresh['steps'][build_step]['steps'] = {}
+
+                        codefresh['steps'][build_step]['steps'][app_name] = build
+                    if CF_STEP_PUBLISH in codefresh['steps']:
+                        if not type(codefresh['steps'][CF_STEP_PUBLISH]['steps']) == dict:
+                            codefresh['steps'][CF_STEP_PUBLISH]['steps'] = {}
+                        codefresh['steps'][CF_STEP_PUBLISH]['steps']['publish_' + app_name] = codefresh_app_publish_spec(
+                            app_name=app_name,
+                            build_tag=build and build['tag'],
+                            base_name=base_image_name
+                        )
+
+            codefresh_build_step_from_base_path(os.path.join(root_path, BASE_IMAGES_PATH), CF_BUILD_STEP_BASE,
+                                                fixed_context=os.path.relpath(root_path, os.getcwd()), include=values_manual_deploy[KEY_TASK_IMAGES].keys())
+            codefresh_build_step_from_base_path(os.path.join(root_path, STATIC_IMAGES_PATH), CF_BUILD_STEP_STATIC,
+                                                include=values_manual_deploy[KEY_TASK_IMAGES].keys())
+            codefresh_build_step_from_base_path(os.path.join(
+                root_path, APPS_PATH), CF_BUILD_STEP_PARALLEL)
+
+    if not codefresh:
+        logging.warning(
+            "No template file found. Codefresh script not created.")
+        return
 
     # Remove useless steps
     codefresh['steps'] = {k: step for k, step in codefresh['steps'].items() if
@@ -130,8 +145,13 @@ def create_codefresh_deployment_scripts(root_paths, env, include=(), exclude=(),
                         environment.append(
                             "CUSTOM_apps_%s_harness_secrets_%s=${{%s}}" % (app_name, secret_name, secret_name.upper()))
 
+    cmds = codefresh['steps']['prepare_deployment']['commands']
+    for i in range(len(cmds)):
+        cmds[i] = cmds[i].replace("$ENV", "-".join(envs))
+
     if save:
-        codefresh_abs_path = os.path.join(os.getcwd(), DEPLOYMENT_PATH, out_filename)
+        codefresh_abs_path = os.path.join(
+            os.getcwd(), DEPLOYMENT_PATH, out_filename)
         codefresh_dir = os.path.dirname(codefresh_abs_path)
         if not os.path.exists(codefresh_dir):
             os.makedirs(codefresh_dir)
@@ -153,11 +173,13 @@ def codefresh_template_spec(template_path, **kwargs):
 
 
 def codefresh_app_publish_spec(app_name, build_tag, base_name=None):
-    title = app_name.capitalize().replace('-', ' ').replace('/', ' ').replace('.', ' ').strip()
+    title = app_name.capitalize().replace(
+        '-', ' ').replace('/', ' ').replace('.', ' ').strip()
 
     step_spec = codefresh_template_spec(
         template_path=CF_TEMPLATE_PUBLISH_PATH,
-        candidate="${{REGISTRY}}/%s:%s" % (get_image_name(app_name, base_name), build_tag or '${{DEPLOYMENT_TAG}}'),
+        candidate="${{REGISTRY}}/%s:%s" % (get_image_name(
+            app_name, base_name), build_tag or '${{DEPLOYMENT_TAG}}'),
         title=title,
     )
     if not build_tag:
@@ -170,9 +192,10 @@ def app_specific_tag_variable(app_name):
     return "${{ %s }}_${{DEPLOYMENT_PUBLISH_TAG}}" % app_name.replace('-', '_').upper()
 
 
-def codefresh_app_build_spec(app_name, app_context_path, dockerfile_path="Dockerfile", base_name=None, helm_values: HarnessMainConfig={}):
+def codefresh_app_build_spec(app_name, app_context_path, dockerfile_path="Dockerfile", base_name=None, helm_values: HarnessMainConfig = {}):
     logging.info('Generating build script for ' + app_name)
-    title = app_name.capitalize().replace('-', ' ').replace('/', ' ').replace('.', ' ').strip()
+    title = app_name.capitalize().replace(
+        '-', ' ').replace('/', ' ').replace('.', ' ').strip()
     build = codefresh_template_spec(
         template_path=CF_BUILD_PATH,
         image_name=get_image_name(app_name, base_name),
@@ -182,11 +205,13 @@ def codefresh_app_build_spec(app_name, app_context_path, dockerfile_path="Docker
 
     specific_build_template_path = os.path.join(app_context_path, 'build.yaml')
     if os.path.exists(specific_build_template_path):
-        logging.info("Specific build template found: %s" % (specific_build_template_path))
+        logging.info("Specific build template found: %s" %
+                     (specific_build_template_path))
         with open(specific_build_template_path) as f:
             build_specific = yaml.safe_load(f)
 
-        build_args = build_specific.pop('build_arguments') if 'build_arguments' in build_specific else []
+        build_args = build_specific.pop(
+            'build_arguments') if 'build_arguments' in build_specific else []
 
     build['build_arguments'].append('REGISTRY=${{REGISTRY}}/%s/' % base_name)
 

--- a/tools/cloudharness_utilities/codefresh.py
+++ b/tools/cloudharness_utilities/codefresh.py
@@ -59,8 +59,9 @@ def create_codefresh_deployment_scripts(root_paths, envs=(), include=(), exclude
             template_name = f"codefresh-template-{e}.yaml"
             template_path = os.path.join(
                 root_path, DEPLOYMENT_CONFIGURATION_PATH, template_name)
-
-            if os.path.exists(template_path):
+            
+            tpl = get_template(template_path, True)
+            if tpl:
                 logging.info("Codefresh template found: %s", template_path)
                 tpl = get_template(template_path, True)
                 if 'steps' in tpl:
@@ -74,6 +75,8 @@ def create_codefresh_deployment_scripts(root_paths, envs=(), include=(), exclude
                         del tpl['steps'][CF_STEP_PUBLISH]
                 codefresh = dict_merge(codefresh, tpl)
 
+            if not 'steps' in codefresh:
+                continue
 
             def codefresh_build_step_from_base_path(base_path, build_step, fixed_context=None, include=include):
 

--- a/tools/cloudharness_utilities/deployment-configuration/codefresh-template-dev.yaml
+++ b/tools/cloudharness_utilities/deployment-configuration/codefresh-template-dev.yaml
@@ -31,7 +31,7 @@ steps:
     working_directory: .
     commands:
       - bash cloud-harness/install.sh
-      - harness-deployment cloud-harness . -t ${{CF_BUILD_ID}} -d ${{DOMAIN}} -r ${{REGISTRY}} -rs ${{REGISTRY_SECRET}} -e dev
+      - harness-deployment cloud-harness . -t ${{CF_BUILD_ID}} -d ${{DOMAIN}} -r ${{REGISTRY}} -rs ${{REGISTRY_SECRET}} -e $ENV
   prepare_deployment_view:
     commands:
       - 'helm template ./deployment/helm --debug -n ${{NAMESPACE}}'

--- a/tools/cloudharness_utilities/deployment-configuration/codefresh-template-prod.yaml
+++ b/tools/cloudharness_utilities/deployment-configuration/codefresh-template-prod.yaml
@@ -30,7 +30,7 @@ steps:
     working_directory: .
     commands:
       - bash cloud-harness/install.sh
-      - harness-deployment . cloud-harness -t ${{DEPLOYMENT_TAG}} -d ${{DOMAIN}} -r ${{REGISTRY}} -rs ${{REGISTRY_SECRET}} -e prod
+      - harness-deployment . cloud-harness -t ${{DEPLOYMENT_TAG}} -d ${{DOMAIN}} -r ${{REGISTRY}} -rs ${{REGISTRY_SECRET}} -e $ENV
   prepare_deployment_view:
     commands:
       - 'helm template ./deployment/helm --debug -n ${{NAMESPACE}}'

--- a/tools/harness-deployment
+++ b/tools/harness-deployment
@@ -47,8 +47,8 @@ if __name__ == "__main__":
                         help='Disable secured gatekeepers access')
     parser.add_argument('-ex', '--exclude', dest='exclude', action="append", default=[],
                         help='Specify application to exclude from the deployment')
-    parser.add_argument('-e', '--env', dest='env', action="store", default=None,
-                        help='Specify the name of the environment (will load values-[ENV].yaml files)')
+    parser.add_argument('-e', '--env', dest='env', action="store", default="",
+                        help='Specify the name of the environment(s) (will load values-[ENV].yaml files). Specify multiple envs with dashes (e.g env1-env2)')
     parser.add_argument('-m', '--merge', dest='merge', action="store", default=None,
                         help='Deprecated -- Merge is now automatic')
 
@@ -61,7 +61,7 @@ if __name__ == "__main__":
 
     root_paths = [os.path.join(os.getcwd(), path) for path in args.paths]
 
-    
+    envs = (args.env.split("-") if "-" in args.env else [args.env])   if args.env else ()
 
     if unknown:
         print('There are unknown args. Make sure to call the script with the accepted args. Try --help')
@@ -86,7 +86,7 @@ if __name__ == "__main__":
             include=args.include,
             registry_secret=args.registry_secret,
             tls=not args.no_tls,
-            env=args.env,
+            env=envs,
             namespace=args.namespace
         )
 
@@ -95,10 +95,10 @@ if __name__ == "__main__":
         build_included = [app['harness']['name']
                           for app in helm_values['apps'].values() if 'harness' in app]
 
-        if args.env:
+        if envs:
 
             create_codefresh_deployment_scripts(root_paths, include=build_included,
-                                                env=args.env,
+                                                envs=envs,
                                                 base_image_name=helm_values['name'],
                                                 values_manual_deploy=helm_values)
 

--- a/tools/tests/resources/applications/myapp/deploy/values-dev.yaml
+++ b/tools/tests/resources/applications/myapp/deploy/values-dev.yaml
@@ -8,3 +8,4 @@ harness:
       - cloudharness-flask
       - my-common
 a: b
+dev: true

--- a/tools/tests/resources/applications/myapp/deploy/values-test.yaml
+++ b/tools/tests/resources/applications/myapp/deploy/values-test.yaml
@@ -1,0 +1,2 @@
+a: test
+test: true

--- a/tools/tests/resources/deployment-configuration/codefresh-template-dev.yaml
+++ b/tools/tests/resources/deployment-configuration/codefresh-template-dev.yaml
@@ -1,1 +1,2 @@
-test_step: True
+test_step: dev
+dev: True

--- a/tools/tests/resources/deployment-configuration/codefresh-template-test.yaml
+++ b/tools/tests/resources/deployment-configuration/codefresh-template-test.yaml
@@ -1,0 +1,2 @@
+test_step: test
+test: True

--- a/tools/tests/test_codefresh.py
+++ b/tools/tests/test_codefresh.py
@@ -45,10 +45,10 @@ def test_create_codefresh_configuration():
     assert step_build_base["type"] == "parallel"
 
     steps = l1_steps["build_base_images"]["steps"]
-    assert len(steps) == 2
-    assert "cloudharness-base" in steps
-    assert "cloudharness-base-debian" not in steps
-    assert "cloudharness-frontend-build" in steps
+    assert len(steps) == 2, "2 base images should be included as dependencies"
+    assert "cloudharness-base" in steps, "cloudharness-base image should be included as dependency"
+    assert "cloudharness-base-debian" not in steps, "cloudharness-base image should not be included"
+    assert "cloudharness-frontend-build" in steps, "cloudharness-frontend-build image should be included as dependency"
 
     step = steps["cloudharness-frontend-build"]
     assert os.path.samefile(step['working_directory'], CLOUDHARNESS_ROOT)
@@ -58,13 +58,16 @@ def test_create_codefresh_configuration():
 
     step = steps["cloudharness-base"]
     assert step['working_directory'] == BUILD_MERGE_DIR, "Overridden base images should build inside the merge directory"
-    assert os.path.samefile(os.path.join(step['working_directory'], step['dockerfile']), os.path.join(step['working_directory'], BASE_IMAGES_PATH, "cloudharness-base", "Dockerfile"))
+    assert os.path.samefile(
+        os.path.join(step['working_directory'], step['dockerfile']), 
+        os.path.join(step['working_directory'], BASE_IMAGES_PATH, "cloudharness-base", "Dockerfile")
+        ), "Not overridden base images should be built from the base directory"
     
 
     steps = l1_steps["build_static_images"]["steps"]
-    assert len(steps) == 2
-    assert "cloudharness-flask" in steps
-    assert "my-common" in steps
+    assert len(steps) == 2, "2 static images should be included as dependencies"
+    assert "cloudharness-flask" in steps, "cloudharness-flask image should be included as dependency"
+    assert "my-common" in steps, "my-common image should be included as dependency"
 
     step = steps["cloudharness-flask"]
     assert step['dockerfile'] == "Dockerfile"

--- a/tools/tests/test_helm.py
+++ b/tools/tests/test_helm.py
@@ -148,6 +148,16 @@ def test_collect_helm_values_precedence():
     assert values[KEY_APPS]['events']['kafka']['resources']['limits']['memory'] == 'overridden'
     assert values[KEY_APPS]['events']['kafka']['resources']['limits']['cpu'] == 'overridden-prod'
 
+def test_collect_helm_values_multiple_envs():
+    values = create_helm_chart([CLOUDHARNESS_ROOT, RESOURCES], output_path=OUT, domain="my.local",
+                               namespace='test', env=['dev', 'test'], local=False, tag=1, include=["myapp"])
+
+    
+    assert values[KEY_APPS]['myapp']['test'] == True, 'values-test not loaded'
+    assert values[KEY_APPS]['myapp']['dev'] == True, 'values-dev not loaded'
+    assert values[KEY_APPS]['myapp']['a'] == 'test', 'values-test not overriding'
+    
+
 
 def test_collect_helm_values_wrong_dependencies_validate():
     try:


### PR DESCRIPTION
Closes #444

Implemented solution: can specify `harness-deployment -e env1-env2`

How to test this PR: Run `harness-deployment -e dev-prod`. A pipeline file deployment/codefresh-dev-prod.yaml is created.
Values in there and in deployment/values.yaml will contain the values from the variuous *-dev and *-prod configuration files

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [x] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [x] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
