### PR TITLE
248/test sequencer

### DIFF
--- a/test/jest-puppeteer/__tests__/common.spec.ts
+++ b/test/jest-puppeteer/__tests__/common.spec.ts
@@ -5,7 +5,7 @@ let browser: any;
 
 describe("Sandbox", () => {
   beforeAll(async () => {
-    browser = await puppeteer.launch({ args: ['--no-sandbox'], headless: false, slowMo: 50, })
+    browser = await puppeteer.launch({ args: ['--no-sandbox'], headless: true, })
 
     page = await browser.newPage();
     page.on('pageerror', ({ message }: any) => expect(message).toBe(""))
@@ -48,12 +48,11 @@ describe("Sandbox", () => {
         }
         });
 
-      await page.type("#username", process.env.USERNAME); // to replace with the username from values-test.yaml
-      await page.type("#password", process.env.PASSWORD); // to replace with the password from values-test.yaml
+      await page.type("#username", process.env.USERNAME); 
+      await page.type("#password", process.env.PASSWORD); 
       await page.keyboard.press("Enter");
       await page.waitForSelector("#user-menu"); 
       await page.waitForTimeout(1000); 
-    
 
     });
   }

--- a/test/jest-puppeteer/__tests__/common.spec.ts
+++ b/test/jest-puppeteer/__tests__/common.spec.ts
@@ -41,6 +41,13 @@ describe("Sandbox", () => {
   if (process.env.USERNAME && process.env.PASSWORD) {
     test("Login", async () => {
 
+      page
+        .on("response", (response: any) => {
+        if (response.status() >= 300) {
+          expect(response.status()).toBeLessThan(400);
+        }
+        });
+
       await page.type("#username", process.env.USERNAME); // to replace with the username from values-test.yaml
       await page.type("#password", process.env.PASSWORD); // to replace with the password from values-test.yaml
       await page.keyboard.press("Enter");

--- a/test/jest-puppeteer/__tests__/common.spec.ts
+++ b/test/jest-puppeteer/__tests__/common.spec.ts
@@ -51,7 +51,9 @@ describe("Sandbox", () => {
       await page.type("#username", process.env.USERNAME); // to replace with the username from values-test.yaml
       await page.type("#password", process.env.PASSWORD); // to replace with the password from values-test.yaml
       await page.keyboard.press("Enter");
-      await page.waitForSelector("#user-menu");     
+      await page.waitForSelector("#user-menu"); 
+      await page.waitForTimeout(1000); 
+    
 
     });
   }

--- a/test/jest-puppeteer/__tests__/common.spec.ts
+++ b/test/jest-puppeteer/__tests__/common.spec.ts
@@ -5,7 +5,7 @@ let browser: any;
 
 describe("Sandbox", () => {
   beforeAll(async () => {
-    browser = await puppeteer.launch({ args: ['--no-sandbox'], })
+    browser = await puppeteer.launch({ args: ['--no-sandbox'], headless: false, slowMo: 50, })
 
     page = await browser.newPage();
     page.on('pageerror', ({ message }: any) => expect(message).toBe(""))
@@ -34,8 +34,18 @@ describe("Sandbox", () => {
   });
 
   test("Check page", async () => {
-
     await page.waitForSelector("body");
 
   });
+
+  if (process.env.USERNAME && process.env.PASSWORD) {
+    test("Login", async () => {
+
+      await page.type("#username", process.env.USERNAME); // to replace with the username from values-test.yaml
+      await page.type("#password", process.env.PASSWORD); // to replace with the password from values-test.yaml
+      await page.keyboard.press("Enter");
+      await page.waitForSelector("#user-menu");     
+
+    });
+  }
 });

--- a/test/jest-puppeteer/jest.config.js
+++ b/test/jest-puppeteer/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   roots: [".", process.env.APP],
   testMatch: ["**__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[tj]s?(x)"],
   testPathIgnorePatterns: ["/node_modules/"],
+  "testSequencer": "./testSequencer.js",
   setupFilesAfterEnv: ["./jest.setup.js"],
   transform: {
     "^.+\\.tsx?$": "ts-jest"

--- a/test/jest-puppeteer/package.json
+++ b/test/jest-puppeteer/package.json
@@ -50,8 +50,8 @@
   "scripts": {
     "lint": "npx tslint -c tslint.json './__tests__/*.ts'",
     "pretty": "npx prettier --no-config './__tests__/*.{js,ts}' --write",
-    "test": "APP=. npx jest",
-    "test:app": "npx jest"
+    "test": "APP=. npx jest --runInBand",
+    "test:app": "npx jest --runInBand"
   },
   "version": "1.0.0"
 }

--- a/test/jest-puppeteer/testSequencer.js
+++ b/test/jest-puppeteer/testSequencer.js
@@ -1,0 +1,30 @@
+const Sequencer = require('@jest/test-sequencer').default;
+
+class CustomSequencer extends Sequencer {
+  // /**
+  //  * Select tests for shard requested via --shard=shardIndex/shardCount
+  //  * Sharding is applied before sorting
+  //  */
+  // shard(tests, {shardIndex, shardCount}) {
+  //   const shardSize = Math.ceil(tests.length / options.shardCount);
+  //   const shardStart = shardSize * (options.shardIndex - 1);
+  //   const shardEnd = shardSize * options.shardIndex;
+
+  //   return [...tests]
+  //     .sort((a, b) => (a.path > b.path ? 1 : -1))
+  //     .slice(shardStart, shardEnd);
+  // }
+
+  /**
+   * Sort test to determine order of execution
+   * Sorting is applied after sharding
+   */
+  sort(tests) {
+    // Test structure information
+    // https://github.com/facebook/jest/blob/6b8b1404a1d9254e7d5d90a8934087a9c9899dab/packages/jest-runner/src/types.ts#L17-L21
+    const copyTests = Array.from(tests);
+    return copyTests.sort((testA, testB) => (testA.path > testB.path ? 1 : -1));
+  }
+}
+
+module.exports = CustomSequencer;


### PR DESCRIPTION


Implemented solution:  The objective was

- to add the testSequencer that allows tests to be ran alphabetically and sequentially 
- to add test case for logging in to the application, when applicable


### Sanity checks:
- [ ] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [ ] From the issue and the current PR it is explicitly stated how to test the current change
- [ ] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [ ] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [ ] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [x] Screenshots of the changes
- [ ] Explanatory video/animated gif

![Screenshot at Jun 09 15-26-51](https://user-images.githubusercontent.com/99416933/172871537-d3893861-4b34-4ea2-b014-bc62126ed7d9.png)
![Screenshot at Jun 09 15-27-20](https://user-images.githubusercontent.com/99416933/172871548-81f2021a-f7a1-4153-b627-bcda872b29da.png)
![Screenshot at Jun 09 15-27-33](https://user-images.githubusercontent.com/99416933/172871552-816eade8-e1be-4951-8f82-5aa559b9c882.png)

