### PR TITLE
#499 Fix codefresh templates overriding

### DIFF
--- a/tools/cloudharness_utilities/codefresh.py
+++ b/tools/cloudharness_utilities/codefresh.py
@@ -53,26 +53,19 @@ def create_codefresh_deployment_scripts(root_paths, envs=(), include=(), exclude
         )
 
     codefresh = {}
+    for e in envs:
+        template_name = f"codefresh-template-{e}.yaml"
+        codefresh = dict_merge(codefresh, get_template(template_name, True))
 
     for root_path in root_paths:
         for e in envs:
             template_name = f"codefresh-template-{e}.yaml"
             template_path = os.path.join(
                 root_path, DEPLOYMENT_CONFIGURATION_PATH, template_name)
-            
-            tpl = get_template(template_path, True)
+
+            tpl = get_template(template_path)
             if tpl:
                 logging.info("Codefresh template found: %s", template_path)
-                tpl = get_template(template_path, True)
-                if 'steps' in tpl:
-                    if codefresh and CF_BUILD_STEP_BASE in codefresh['steps']:
-                        del tpl['steps'][CF_BUILD_STEP_BASE]
-                    if codefresh and CF_BUILD_STEP_STATIC in codefresh['steps']:
-                        del tpl['steps'][CF_BUILD_STEP_STATIC]
-                    if codefresh and CF_BUILD_STEP_PARALLEL in codefresh['steps']:
-                        del tpl['steps'][CF_BUILD_STEP_PARALLEL]
-                    if codefresh and CF_STEP_PUBLISH in codefresh['steps']:
-                        del tpl['steps'][CF_STEP_PUBLISH]
                 codefresh = dict_merge(codefresh, tpl)
 
             if not 'steps' in codefresh:

--- a/tools/tests/resources/deployment-configuration/codefresh-template-dev.yaml
+++ b/tools/tests/resources/deployment-configuration/codefresh-template-dev.yaml
@@ -1,2 +1,5 @@
 test_step: dev
 dev: True
+steps:
+  main_clone:
+    title: Overridden

--- a/tools/tests/test_codefresh.py
+++ b/tools/tests/test_codefresh.py
@@ -40,6 +40,9 @@ def test_create_codefresh_configuration():
 
     assert "test_step" in cf
 
+    assert cf['steps']['main_clone']['title'] == 'Overridden', "Steps overriding is not working correctly"
+    assert cf['steps']['main_clone']['type'] == 'git-clone', "Steps overriding missing values from the parent"
+
     l1_steps = cf['steps']
     step_build_base = l1_steps["build_base_images"]
     assert step_build_base["type"] == "parallel"


### PR DESCRIPTION
Closes #499

Implemented solution: the issue was in the way that the default templates were used at every step while scanning the directory: that was causing the default template to be used while scanning in the .overrides directory (that's why the bug was not appearing for deployments without overrides)

How to test this PR: Override `deployment-configuration/codefresh-template-dev.yaml` and run `harness-deployment ... -e dev` and check the result. At least one application must be overridden in order for the fix to be evident.

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [x] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
