### PR TITLE
Workflows and volumes enhancements

### DIFF
--- a/docs/applications/development/workflows-api.md
+++ b/docs/applications/development/workflows-api.md
@@ -114,7 +114,15 @@ The shared volume must be indicated both in the Operation and it is propagated t
 The `shared_directory` parameter is a quick way to specify a shared directory, and, optionally,
 the name of a volume claim. 
 
-The syntax is `[CLAIM_NAME:]MOUNT_PATH`.
+The syntax is `[CLAIM_NAME:]MOUNT_PATH[:MODE]`.
+- The `CLAIM_NAME` can be an existing or new volume claim name. In the case a claim already exists with that name it will be used.
+Otherwise a new ephemeral volume is created: that volume will exist during the life of the workflow and deleted after completion
+- The `MOUNT_PATH` is the path where we want the volume to be mounted inside our pod
+- The appendix `:MODE` indicated the read/write mode. If `ro`, the
+volume is mounted as read-only. Read only volumes are useful to overcome
+scheduling limitations (ReadWriteOnce is usually available) when 
+writing is not required, and it's generally recommended whenever writing
+is not required.
 
 ```Python
 shared_directory="myclaim:/opt/shared"
@@ -126,11 +134,13 @@ op.execute()
 More than one directory/volume can be shared by passing a list/tuple:
 
 ```Python
-shared_directory=["myclaim:/opt/shared", "myclaim2:/opt/shared2"]
+shared_directory=["myclaim:/opt/shared:ro", "myclaim2:/opt/shared2"]
 my_task = tasks.CustomTask('print-file', 'myapp-mytask')
 op = operations.SingleTaskOperation('my-op-', my_task, shared_directory=shared_directory)
 op.execute()
 ```
+
+
 
 ## Pod execution context / affinity
 

--- a/docs/applications/development/workflows-api.md
+++ b/docs/applications/development/workflows-api.md
@@ -154,10 +154,24 @@ op = operations.ParallelOperation('test-parallel-op-', (tasks.PythonTask('p1', f
                                       pod_context=operations.PodExecutionContext(key='a', value='b', required=True))
 ```
 
+
+
 The execution context is set allows to group pods in the same node (see [here](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)).
 This is important in particular when pods are sharing node resources like ReadWriteOnce volumes within a parallel execution or with other deployments in the cluster.
 The execution context sets the affinity and the metadata attributes so that all pods with the same context
-run in the same node 
+run in the same node.
+
+
+Is is also possible to specify a tuple or list for multiple affinities like:
+
+```Python
+op = operations.ParallelOperation('test-parallel-op-', (tasks.PythonTask('p1', f), tasks.PythonTask('p2', f)),
+                                      pod_context=(
+                                        operations.PodExecutionContext('a', 'b'), 
+                                        operations.PodExecutionContext('c', 'd', required=True), 
+                                        operations.PodExecutionContext('e', 'f')
+                                        ))
+```
 
 ## TTL (Time-To-Live) strategy
 

--- a/libraries/cloudharness-common/cloudharness/workflows/operations.py
+++ b/libraries/cloudharness-common/cloudharness/workflows/operations.py
@@ -231,9 +231,14 @@ class ContainerizedOperation(ManagedOperation):
 
     def volume_template(self, volume):
         path = volume
-        if ":" in path:
-            path = volume.split(':')[-1]
-        return dict({'name': self.name_from_path(path), 'mountPath': path})
+        splitted = volume.split(':')[1]
+        if len(splitted) > 1:
+            path = splitted[1]
+        return dict({
+            'name': self.name_from_path(path), 
+            'mountPath': path,
+            'readonly': False if len(splitted) < 3 else splitted[2] == "ro"
+            })
         
     def spec_volumeclaim(self, volume):
         # when the volume is NOT prefixed by a PVC (e.g. /location) then create a temporary PVC for the workflow
@@ -262,7 +267,8 @@ class ContainerizedOperation(ManagedOperation):
                 'name': self.name_from_path(path),
                 'persistentVolumeClaim': {
                     'claimName': pvc
-                }
+                },
+                
             }
         return {}
 

--- a/libraries/cloudharness-common/cloudharness/workflows/operations.py
+++ b/libraries/cloudharness-common/cloudharness/workflows/operations.py
@@ -275,7 +275,7 @@ class ContainerizedOperation(ManagedOperation):
     def spec_volume(self, volume):
         # when the volume is prefixed by a PVC (e.g. pvc-001:/location) then add the PVC to the volumes of the workflow
         if ':' in volume:
-            pvc, path = volume.split(':')
+            pvc, path, *c = volume.split(':')
             return {
                 'name': self.name_from_path(path),
                 'persistentVolumeClaim': {

--- a/libraries/cloudharness-common/tests/test_workflow.py
+++ b/libraries/cloudharness-common/tests/test_workflow.py
@@ -126,6 +126,14 @@ def test_single_task_shared_multiple():
     assert len(wf['spec']['templates'][0]['container']['volumeMounts']) == 3
 
     assert wf['spec']['templates'][0]['container']['volumeMounts'][2]['readonly'] == True
+
+    assert wf['spec']['templates'][0]['metadata']['labels']['usesvolume']
+
+    assert 'affinity' in wf['spec']
+    assert len(wf['spec']['affinity']['podAffinity']['requiredDuringSchedulingIgnoredDuringExecution']) == 2, "A pod affinity for each volume is expected"
+    affinity_expr = wf['spec']['affinity']['podAffinity']['requiredDuringSchedulingIgnoredDuringExecution'][0]['labelSelector']['matchExpressions'][0]
+    assert affinity_expr['key'] == 'usesvolume'
+    assert affinity_expr['values'][0] == 'myclaim'
     if execute:
         print(op.execute())
 
@@ -141,6 +149,7 @@ def test_single_task_shared_script():
     assert len(wf['spec']['volumes']) == 2
     assert wf['spec']['volumes'][1]['persistentVolumeClaim']['claimName'] == 'myclaim'
     assert len(wf['spec']['templates'][0]['script']['volumeMounts']) == 2
+    
     if execute:
         print(op.execute())
 

--- a/libraries/cloudharness-common/tests/test_workflow.py
+++ b/libraries/cloudharness-common/tests/test_workflow.py
@@ -112,7 +112,7 @@ def test_single_task_shared():
 
 
 def test_single_task_shared_multiple():
-    shared_directory = ['myclaim:/mnt/shared', 'myclaim2:/mnt/shared2']
+    shared_directory = ['myclaim:/mnt/shared', 'myclaim2:/mnt/shared2:ro']
     task_write = operations.CustomTask('download-file', 'workflows-extract-download',
                                        url='https://raw.githubusercontent.com/openworm/org.geppetto/master/README.md')
     op = operations.SingleTaskOperation('test-custom-connected-op-', task_write,
@@ -124,6 +124,8 @@ def test_single_task_shared_multiple():
     assert len(wf['spec']['volumes']) == 3
     assert wf['spec']['volumes'][1]['persistentVolumeClaim']['claimName'] == 'myclaim'
     assert len(wf['spec']['templates'][0]['container']['volumeMounts']) == 3
+
+    assert wf['spec']['templates'][0]['container']['volumeMounts'][2]['readonly'] == True
     if execute:
         print(op.execute())
 


### PR DESCRIPTION
Closes #505 
Closes #506 
Closes #512 

**Implemented solution**

#506: Readonly volumes can be added with the `:ro` at the end of the shared_directory string.
#505: Multiple values are allowed for `pod_context` as list or tuple  https://github.com/MetaCell/cloud-harness/blob/6bb7a96ef9b2e3530696ec93488d2f1c2258ca90/libraries/cloudharness-common/tests/test_workflow.py#L236
#512 pod contexts are added automatically for volumes specified as shared_directory

How to test this PR:
Unit tests are covering the functionality.

Create an operation like
```
op = operations.ParallelOperation('test-parallel-op-', (tasks.PythonTask('p1', f), tasks.PythonTask('p2', f)),
                                      pod_context=(
                                        operations.PodExecutionContext('a', 'b'), 
                                        operations.PodExecutionContext('c', 'd', required=True), 
                                        operations.PodExecutionContext('e', 'f')
                                        )), shared_directory = 'myclaim:/mnt/shared:ro'

```
and see that the workflow specification has 4 affinity terms 2 required, 2 preferred and a readonly mounted volume

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [x] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [x] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
