### PR TITLE
#510 remove double volume type spec

### DIFF
--- a/tools/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
+++ b/tools/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-    - ReadOnlyMany
   resources:
     requests:
       storage: {{ .Values.backup.volumesize }}


### PR DESCRIPTION
Closes #510 

Implemented solution: see task #510 description

How to test this PR: deployments are affected by this change only if backups are enabled. Spin up a deployment with at least one database and enabled backups on GCP and verify that pods and cron jobs are not deadlocking.

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [ ] There is no reason why deployments based on CloudHarness may break after the current update
- [x] This PR and the issue are tagged as `alert:deployment`

The backup volumes are redefined so the new specification will clash with the old one and the backup volume db-backups may need to be removed and recreated.

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
