### PR TITLE
#543 chore: Add openapi generator requirements overrides

### DIFF
--- a/tools/cloudharness_utilities/openapi-generator-overrides/requirements.mustache
+++ b/tools/cloudharness_utilities/openapi-generator-overrides/requirements.mustache
@@ -1,0 +1,28 @@
+connexion[swagger-ui] >= 2.6.0; python_version>="3.6"
+# 2.3 is the last version that supports python 3.4-3.5
+connexion[swagger-ui] <= 2.3.0; python_version=="3.5" or python_version=="3.4"
+{{#supportPython2}}
+    connexion[swagger-ui] == 2.4.0; python_version<="2.7"
+{{/supportPython2}}
+# connexion requires werkzeug but connexion < 2.4.0 does not install werkzeug
+# we must peg werkzeug versions below to fix connexion
+# https://github.com/zalando/connexion/pull/1044
+werkzeug == 0.16.1; python_version=="3.5" or python_version=="3.4"
+swagger-ui-bundle >= 0.0.2
+python_dateutil >= 2.6.0
+{{#featureCORS}}
+    # should support both Python 2 and Python 3
+    flask-cors >= 3.0.10
+{{/featureCORS}}
+{{#supportPython2}}
+    typing >= 3.5.2.2
+    # For specs with timestamps, pyyaml 5.3 broke connexion's spec parsing in python 2.
+    # Connexion uses copy.deepcopy() on the spec, thus hitting this bug:
+    # https://github.com/yaml/pyyaml/issues/387
+    pyyaml < 5.3; python_version<="2.7"
+{{/supportPython2}}
+setuptools >= 21.0.0
+Flask == 1.1.2
+Jinja2==3.0.3
+itsdangerous==2.0.1
+Werkzeug==2.0.3

--- a/tools/cloudharness_utilities/openapi.py
+++ b/tools/cloudharness_utilities/openapi.py
@@ -25,7 +25,8 @@ def generate_server(app_path):
     out_name = f"backend" if not os.path.exists(
         f"{app_path}/server") else f"server"
     out_path = f"{app_path}/{out_name}"
-    command = f"java -jar {CODEGEN} generate -i {openapi_file} -g python-flask -o {out_path} -c {openapi_dir}/config.json"
+    command = f"java -jar {CODEGEN} generate -i {openapi_file} -g python-flask -o {out_path} " \
+              f"-c {openapi_dir}/config.json -t {HERE}/openapi-generator-overrides"
     os.system(command)
 
 
@@ -39,7 +40,7 @@ def generate_model(base_path=ROOT):
     # Generate docs: use python generator
     tmp_path = f"{lib_path}/tmp"
     command = f"java -jar {CODEGEN} generate -i {base_path}/libraries/api/openapi.yaml -g python -o {tmp_path}  --skip-validate-spec -c {base_path}/libraries/api/config.json"
-    
+
     os.system(command)
     try:
         source_dir = join(tmp_path, "docs")


### PR DESCRIPTION
Closes #543

Implemented solution: Overrides openapi-generator requirements.txt with missing requirements

How to test this PR: 
- Follow the steps described in the issue.

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [ ] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope
