### PR TITLE
#525 fixes None type error when setting an attribute on an user without attributes

### DIFF
--- a/libraries/cloudharness-common/cloudharness/auth/keycloak.py
+++ b/libraries/cloudharness-common/cloudharness/auth/keycloak.py
@@ -536,7 +536,7 @@ class AuthClient():
         """
         admin_client=self.get_admin_client()
         user=self.get_user(user_id)
-        attributes=user.get('attributes', {})
+        attributes=user.get('attributes', {}) or {}
         attributes[attribute_name]=attribute_value
         admin_client.update_user(
             user_id,


### PR DESCRIPTION


Closes #525

Implemented solution: added or {}

How to test this PR: create a KC user and try setting the attributes throught the ch auth api

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
