### PR TITLE
Feature/532 Django app configuration to enable keycloak gatekeeper integration

### DIFF
--- a/applications/accounts/Dockerfile
+++ b/applications/accounts/Dockerfile
@@ -7,3 +7,6 @@ USER jboss
 
 # Customize keycloak look
 COPY themes/custom /opt/jboss/keycloak/themes/custom
+
+# keycloak kafka listener plugin
+COPY plugins/metacell-admin-event-listener-bundle-1.0.0.ear /opt/jboss/keycloak/standalone/deployments/

--- a/applications/accounts/admin-event-listener/.gitignore
+++ b/applications/accounts/admin-event-listener/.gitignore
@@ -1,0 +1,13 @@
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+
+.idea/

--- a/applications/accounts/admin-event-listener/README.md
+++ b/applications/accounts/admin-event-listener/README.md
@@ -1,0 +1,14 @@
+# Admin Event Listener for Keycloak
+
+## Building
+```
+mvn clean install
+cp ./ear-module/target/metacell-admin-event-listener-bundle-0.1.0.ear ../plugins/
+```
+
+## Install
+
+* Build the accounts image (run harness-deploy and helm install/upgrade commands)
+* Log into the Keycloak admin
+* open the Manage / Events page
+* go to the Config tab and add the metacell-admin-event-listener to the Event listeners

--- a/applications/accounts/admin-event-listener/ear-module/pom.xml
+++ b/applications/accounts/admin-event-listener/ear-module/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>us.metacellllc.keycloak</groupId>
+        <artifactId>metacell-admin-event-listener</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>metacell-admin-event-listener-bundle</artifactId>
+    <packaging>ear</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>us.metacellllc.keycloak</groupId>
+            <artifactId>metacell-admin-event-listener-module</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ear-plugin</artifactId>
+                <configuration>
+                    <includeLibInApplicationXml>true</includeLibInApplicationXml>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+</project>

--- a/applications/accounts/admin-event-listener/jar-module/pom.xml
+++ b/applications/accounts/admin-event-listener/jar-module/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>us.metacellllc.keycloak</groupId>
+        <artifactId>metacell-admin-event-listener</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <name>Metacell Admin Event Listener</name>
+    <description/>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>metacell-admin-event-listener-module</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+            <version>6.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi</artifactId>
+            <version>6.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi-private</artifactId>
+            <version>6.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-services</artifactId>
+            <version>6.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-core-public</artifactId>
+            <version>6.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/applications/accounts/admin-event-listener/jar-module/src/main/java/us/metacellllc/admineventlistenerprovider/provider/AdminEventKafkaProducer.java
+++ b/applications/accounts/admin-event-listener/jar-module/src/main/java/us/metacellllc/admineventlistenerprovider/provider/AdminEventKafkaProducer.java
@@ -1,0 +1,59 @@
+package us.metacellllc.admineventlistenerprovider.provider;
+
+import java.util.Properties;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+public class AdminEventKafkaProducer {
+
+   private String topicName = "keycloak.fct.admin";
+   private Properties props = new Properties();;
+
+   public AdminEventKafkaProducer() {
+      //Assign localhost id
+      props.put("bootstrap.servers", "kafka-0.broker:9092");
+      
+      //Set acknowledgements for producer requests.      
+      props.put("acks", "all");
+      
+      //If the request fails, the producer can automatically retry,
+      props.put("retries", 0);
+      
+      //Specify buffer size in config
+      props.put("batch.size", 16384);
+      
+      //Reduce the no of requests less than 0   
+      props.put("linger.ms", 1);
+      
+      //The buffer.memory controls the total amount of memory available to the producer for buffering.   
+      props.put("buffer.memory", 33554432);
+      
+      props.put("value.serializer","org.apache.kafka.common.serialization.StringSerializer");
+      props.put("key.serializer","org.apache.kafka.common.serialization.StringSerializer");
+   }
+ 
+   public void SendMessage(String resourceType, String operationType, String resourcePath) throws Exception{
+      // workaround for jvm not discovering the kafka serializer classes
+      Thread.currentThread().setContextClassLoader(null);
+
+      Producer<String, String> producer = new KafkaProducer
+         <String, String>(props);
+    
+      String key = resourcePath;
+      StringBuilder sbValue = new StringBuilder();
+      sbValue.append("{");
+      sbValue.append("\"resource-type\": \""+resourceType+"\",");
+      sbValue.append("\"operation-type\": \""+operationType+"\",");
+      sbValue.append("\"resource-path\": \""+resourcePath+"\"");
+      sbValue.append("}");
+      System.out.println("Sending message "+sbValue.toString());
+      producer.send(new ProducerRecord<String, String>(topicName, 
+         resourceType, sbValue.toString()));
+      System.out.println("Message sent successfully");
+      producer.close();
+   }
+}

--- a/applications/accounts/admin-event-listener/jar-module/src/main/java/us/metacellllc/admineventlistenerprovider/provider/AdminEventListenerProvider.java
+++ b/applications/accounts/admin-event-listener/jar-module/src/main/java/us/metacellllc/admineventlistenerprovider/provider/AdminEventListenerProvider.java
@@ -1,0 +1,99 @@
+package us.metacellllc.admineventlistenerprovider.provider;
+
+import org.keycloak.events.Event;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.admin.AdminEvent;
+import org.keycloak.events.admin.ResourceType;
+import org.keycloak.events.admin.OperationType;
+
+import java.util.Map;
+
+public class AdminEventListenerProvider implements EventListenerProvider {
+
+    @Override
+    public void onEvent(Event event) {
+        // Do Nothing with normal events....
+        // System.out.println("Event Occurred:" + toString(event));
+    }
+
+    @Override
+    public void onEvent(AdminEvent adminEvent, boolean b) {
+        onAdminEvent(adminEvent, b);
+    }
+
+    @Override
+    public void close() {
+    }
+
+    private void onAdminEvent(AdminEvent adminEvent, boolean b) {
+        System.out.println("Handle new Admin Event, resource path: " + adminEvent.getResourcePath());
+        try {
+            new AdminEventKafkaProducer().SendMessage(adminEvent.getResourceType().toString(), adminEvent.getOperationType().toString(), adminEvent.getResourcePath());
+        } catch (Exception e) {
+            System.out.println("Error Occurred:");
+            System.out.println(e);
+        }
+    }
+
+    private String toString(Event event) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("type=");
+        sb.append(event.getType());
+        sb.append(", realmId=");
+        sb.append(event.getRealmId());
+        sb.append(", clientId=");
+        sb.append(event.getClientId());
+        sb.append(", userId=");
+        sb.append(event.getUserId());
+        sb.append(", ipAddress=");
+        sb.append(event.getIpAddress());
+
+        if (event.getError() != null) {
+            sb.append(", error=");
+            sb.append(event.getError());
+        }
+
+        if (event.getDetails() != null) {
+            sb.append(", details: ");
+            for (Map.Entry<String, String> e : event.getDetails().entrySet()) {
+                sb.append(", ");
+                sb.append(e.getKey());
+                if (e.getValue() == null || e.getValue().indexOf(' ') == -1) {
+                    sb.append("=");
+                    sb.append(e.getValue());
+                } else {
+                    sb.append("='");
+                    sb.append(e.getValue());
+                    sb.append("'");
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+
+    private String toString(AdminEvent adminEvent) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("operationType=");
+        sb.append(adminEvent.getOperationType());
+        sb.append(", realmId=");
+        sb.append(adminEvent.getAuthDetails().getRealmId());
+        sb.append(", clientId=");
+        sb.append(adminEvent.getAuthDetails().getClientId());
+        sb.append(", userId=");
+        sb.append(adminEvent.getAuthDetails().getUserId());
+        sb.append(", ipAddress=");
+        sb.append(adminEvent.getAuthDetails().getIpAddress());
+        sb.append(", resourcePath=");
+        sb.append(adminEvent.getResourcePath());
+
+        if (adminEvent.getError() != null) {
+            sb.append(", error=");
+            sb.append(adminEvent.getError());
+        }
+
+        return sb.toString();
+    }
+}

--- a/applications/accounts/admin-event-listener/jar-module/src/main/java/us/metacellllc/admineventlistenerprovider/provider/AdminEventListenerProviderFactory.java
+++ b/applications/accounts/admin-event-listener/jar-module/src/main/java/us/metacellllc/admineventlistenerprovider/provider/AdminEventListenerProviderFactory.java
@@ -1,0 +1,32 @@
+package us.metacellllc.admineventlistenerprovider.provider;
+
+import org.keycloak.Config;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventListenerProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+public class AdminEventListenerProviderFactory implements EventListenerProviderFactory {
+
+    @Override
+    public EventListenerProvider create(KeycloakSession keycloakSession) {
+        return new AdminEventListenerProvider();
+    }
+
+    @Override
+    public void init(Config.Scope scope) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory keycloakSessionFactory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return "metacell-admin-event-listener";
+    }
+}

--- a/applications/accounts/admin-event-listener/jar-module/src/main/resources/META-INF/jboss-deployment-structure.xml
+++ b/applications/accounts/admin-event-listener/jar-module/src/main/resources/META-INF/jboss-deployment-structure.xml
@@ -1,0 +1,12 @@
+<jboss-deployment-structure>
+    <deployment>
+        <dependencies>
+            <module name="org.keycloak.keycloak-core"/>
+            <module name="org.keycloak.keycloak-server-spi"/>
+            <module name="org.keycloak.keycloak-server-spi-private"/>
+            <module name="org.keycloak.keycloak-services"/>
+            <module name="org.keycloak.keycloak-saml-core-public"/>
+            <module name="org.jboss.logging"/>
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>

--- a/applications/accounts/admin-event-listener/jar-module/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
+++ b/applications/accounts/admin-event-listener/jar-module/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
@@ -1,0 +1,1 @@
+us.metacellllc.admineventlistenerprovider.provider.AdminEventListenerProviderFactory

--- a/applications/accounts/admin-event-listener/pom.xml
+++ b/applications/accounts/admin-event-listener/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+
+    <groupId>us.metacellllc.keycloak</groupId>
+    <artifactId>metacell-admin-event-listener</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>ear-module</module>
+        <module>jar-module</module>
+    </modules>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
+        <lombok.version>1.18.12</lombok.version>
+        <jboss-logging.version>3.3.1.Final</jboss-logging.version>
+        <keycloak.version>6.0.1</keycloak.version>
+        <auto-service.version>1.0-rc5</auto-service.version>
+        <jboss.home>target/keycloak</jboss.home>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.auto.service</groupId>
+                <artifactId>auto-service</artifactId>
+                <version>${auto-service.version}</version>
+                <scope>provided</scope>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>2.5.0</version>
+            </dependency>
+    
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <version>7</version>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>1.2.0.Final</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tools/cloudharness_utilities/application-templates/django-app/README.md
+++ b/tools/cloudharness_utilities/application-templates/django-app/README.md
@@ -7,6 +7,19 @@ It can be also run locally for development and test purpose.
 The code is generated with the script `harness-application` and is in part automatically generated 
 from [openapi definition](./api/openapi.yaml).
 
+## Configuration
+
+### Accounts
+
+The CloudHarness Django application template comes with a configuration that can retrieve user account updates from Keycloak (accounts)
+To enable this feature:
+* log in into the accounts admin interface
+* select in the left sidebar Events
+* select the `Config` tab
+* enable "metacell-admin-event-listener" under the `Events Config` - `Event Listeners`
+
+An other option is to enable the "metacell-admin-event-listener" through customizing the Keycloak realm.json from the CloudHarness repository.
+
 ## Develop
 
 This application is composed of a FastAPI Django backend and a React frontend.

--- a/tools/cloudharness_utilities/application-templates/django-app/deploy/values.yaml
+++ b/tools/cloudharness_utilities/application-templates/django-app/deploy/values.yaml
@@ -1,4 +1,5 @@
 harness:
+  secured: true
   dependencies:
     hard:
     - common
@@ -9,3 +10,10 @@ harness:
     - cloudharness-django
   use_services:
     - name: common
+  uri_role_mapping:
+    - uri: /*
+      roles:
+        - __APP_NAME__:__APP_NAME__-administrator
+        - __APP_NAME__:__APP_NAME__-manager
+        - __APP_NAME__:__APP_NAME__-user
+      require-any-role: true

--- a/tools/harness-application
+++ b/tools/harness-application
@@ -70,13 +70,18 @@ if __name__ == "__main__":
 
     if "django-app" in templates:
         generate_fastapi_server(app_path)
+        replace_in_file(
+            os.path.join(app_path, 'deploy/values.yaml'),
+            f"{PLACEHOLDER}:{PLACEHOLDER}",
+            f"{to_python_module(args.name)}:{to_python_module(args.name)}"
+        )
         try:
             os.remove(os.path.join(app_path, 'backend', "__APP_NAME__", "__main__.py"))
         except FileNotFoundError:
             # backend dockerfile not found, continue
             pass
 
-    replaceindir(app_path, PLACEHOLDER, to_python_module(args.name))
+    replaceindir(app_path, PLACEHOLDER, args.name)
 
     if 'webapp' in templates:
         try:

--- a/tools/harness-application
+++ b/tools/harness-application
@@ -76,7 +76,7 @@ if __name__ == "__main__":
             # backend dockerfile not found, continue
             pass
 
-    replaceindir(app_path, PLACEHOLDER, args.name)
+    replaceindir(app_path, PLACEHOLDER, to_python_module(args.name))
 
     if 'webapp' in templates:
         try:

--- a/tools/harness-generate
+++ b/tools/harness-generate
@@ -6,8 +6,8 @@ import shutil
 import sys
 import logging
 
-from cloudharness_utilities.openapi import LIB_NAME, generate_python_client, generate_server, get_dependencies, \
-    generate_ts_client, generate_model
+from cloudharness_utilities.openapi import LIB_NAME, generate_python_client, generate_server, generate_fastapi_server, \
+    get_dependencies, generate_ts_client, generate_model
 from cloudharness_utilities.utils import copymergedir
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -32,7 +32,11 @@ def generate_servers(root_path, interactive=False):
         if not interactive or input("Do you want to generate " + openapi_files[i] + "? [Y/n]").upper() != 'N':
             openapi_file = openapi_files[i]
             application_root = os.path.dirname(os.path.dirname(openapi_file))
-            generate_server(application_root)
+            if os.path.exists(os.path.join(application_root, "api", "genapi.sh")):
+                # fastapi server --> use the genapi.sh script
+                generate_fastapi_server(application_root)
+            else:
+                generate_server(application_root)
 
 
 def aggregate_packages(client_src_path, lib_name=LIB_NAME):


### PR DESCRIPTION
Closes #532 

Implemented solution: set secure to true and create default uri-role-mappings

How to test this PR: create a sample application and deploy it in your minikube and try to access the `/admin/` page

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [x] The documentation has been updated to match the current changes, see readme of the django-app template
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
