### PR TITLE
Feature/538

### DIFF
--- a/tools/cloudharness_utilities/application-templates/django-app/README.md
+++ b/tools/cloudharness_utilities/application-templates/django-app/README.md
@@ -73,3 +73,10 @@ start the FastAPI server
 ```bash
 uvicorn --workers 2 --host 0.0.0.0 --port 8000 main:app
 ```
+
+
+### Running local with port forwardings to a kubernetes cluster
+When you create port forwards to microservices in your k8s cluster you want to forced your local backend server to initialize
+the AuthService and EventService services.
+This can be done by setting the `KUBERNETES_SERVICE_HOST` environment variable to a dummy or correct k8s service host.
+The `KUBERNETES_SERVICE_HOST` switch will activate the creation of the keycloak client and client roles of this microservice.

--- a/tools/cloudharness_utilities/application-templates/django-app/api/openapi.yaml
+++ b/tools/cloudharness_utilities/application-templates/django-app/api/openapi.yaml
@@ -46,3 +46,5 @@ paths:
                 type: string
           description: Ready
       security: []
+security:
+  - bearerAuth: []

--- a/tools/cloudharness_utilities/application-templates/django-app/api/templates/main.jinja2
+++ b/tools/cloudharness_utilities/application-templates/django-app/api/templates/main.jinja2
@@ -60,12 +60,12 @@ async def add_process_time_header(request: Request, call_next):
 
     return await call_next(request)
 
-# init the auth service
-from cloudharness_django.services import init_services, get_auth_service
-init_services()
-
-# start the kafka event listener
-import cloudharness_django.services.events
+if os.environ.get('KUBERNETES_SERVICE_HOST', None):
+    # init the auth service when running in/for k8s
+    from cloudharness_django.services import init_services, get_auth_service
+    init_services()
+    # start the kafka event listener when running in/for k8s
+    import cloudharness_django.services.events
 
 # enable the Bearer Authentication
 security = HTTPBearer()
@@ -74,6 +74,8 @@ async def has_access(credentials: HTTPBasicCredentials = Depends(security)):
     """
     Function that is used to validate the token in the case that it requires it
     """
+    if not os.environ.get('KUBERNETES_SERVICE_HOST', None):
+        return {}
     token = credentials.credentials
 
     try:

--- a/tools/harness-application
+++ b/tools/harness-application
@@ -69,6 +69,7 @@ if __name__ == "__main__":
         replace_in_file(os.path.join(app_path, 'api/config.json'), PLACEHOLDER, to_python_module(args.name))
 
     if "django-app" in templates:
+        replace_in_file(os.path.join(app_path, 'api/templates/main.jinja2'), PLACEHOLDER, to_python_module(args.name))
         generate_fastapi_server(app_path)
         replace_in_file(
             os.path.join(app_path, 'deploy/values.yaml'),


### PR DESCRIPTION
Closes #538 

Implemented solution: safe guard around the k8s service initialisation

How to test this PR: recreate a microservice of the django-app template and test running `./manage.py runserver`

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
