### PR TITLE
#548 dynamic generation of codefresh prepare cmd

### DIFF
--- a/tools/cloudharness_utilities/codefresh.py
+++ b/tools/cloudharness_utilities/codefresh.py
@@ -37,13 +37,14 @@ def create_codefresh_deployment_scripts(root_paths, envs=(), include=(), exclude
     """
     Entry point to create deployment scripts for codefresh: codefresh.yaml and helm chart
     """
-
+    build_included = [app['harness']['name']
+                            for app in values_manual_deploy['apps'].values() if 'harness' in app]
     out_filename = f"codefresh-{'-'.join(envs)}.yaml"
 
-    if include:
+    if build_included:
         logging.info(
             'Including the following subpaths to the build: %s.', ', '
-            .join(include)
+            .join(build_included)
         )
 
     if exclude:
@@ -71,7 +72,7 @@ def create_codefresh_deployment_scripts(root_paths, envs=(), include=(), exclude
             if not 'steps' in codefresh:
                 continue
 
-            def codefresh_build_step_from_base_path(base_path, build_step, fixed_context=None, include=include):
+            def codefresh_build_step_from_base_path(base_path, build_step, fixed_context=None, include=build_included):
 
                 for dockerfile_path in find_dockerfiles_paths(base_path):
                     app_relative_to_root = os.path.relpath(
@@ -142,8 +143,15 @@ def create_codefresh_deployment_scripts(root_paths, envs=(), include=(), exclude
                             "CUSTOM_apps_%s_harness_secrets_%s=${{%s}}" % (app_name, secret_name, secret_name.upper()))
 
     cmds = codefresh['steps']['prepare_deployment']['commands']
+    
+    params = [p for inc in include for p in ["-i", inc]] +\
+        [p for ex in exclude for p in ["-i", ex]] 
+
     for i in range(len(cmds)):
         cmds[i] = cmds[i].replace("$ENV", "-".join(envs))
+        cmds[i] = cmds[i].replace("$PARAMS", " ".join(params))
+        cmds[i] = cmds[i].replace("$PATHS", " ".join(os.path.relpath(
+                                    root_path, '.') for root_path in root_paths))
 
     if save:
         codefresh_abs_path = os.path.join(

--- a/tools/cloudharness_utilities/deployment-configuration/codefresh-template-dev.yaml
+++ b/tools/cloudharness_utilities/deployment-configuration/codefresh-template-dev.yaml
@@ -31,7 +31,7 @@ steps:
     working_directory: .
     commands:
       - bash cloud-harness/install.sh
-      - harness-deployment cloud-harness . -t ${{CF_BUILD_ID}} -d ${{DOMAIN}} -r ${{REGISTRY}} -rs ${{REGISTRY_SECRET}} -e $ENV
+      - harness-deployment $PATHS -t ${{CF_BUILD_ID}} -d ${{DOMAIN}} -r ${{REGISTRY}} -rs ${{REGISTRY_SECRET}} -n ${{NAMESPACE}} -e $ENV $PARAMS
   prepare_deployment_view:
     commands:
       - 'helm template ./deployment/helm --debug -n ${{NAMESPACE}}'

--- a/tools/cloudharness_utilities/deployment-configuration/codefresh-template-prod.yaml
+++ b/tools/cloudharness_utilities/deployment-configuration/codefresh-template-prod.yaml
@@ -30,7 +30,7 @@ steps:
     working_directory: .
     commands:
       - bash cloud-harness/install.sh
-      - harness-deployment . cloud-harness -t ${{DEPLOYMENT_TAG}} -d ${{DOMAIN}} -r ${{REGISTRY}} -rs ${{REGISTRY_SECRET}} -e $ENV
+      - harness-deployment $PATHS -t ${{CF_BUILD_ID}} -d ${{DOMAIN}} -r ${{REGISTRY}} -rs ${{REGISTRY_SECRET}} -n ${{NAMESPACE}} -e $ENV $PARAMS
   prepare_deployment_view:
     commands:
       - 'helm template ./deployment/helm --debug -n ${{NAMESPACE}}'

--- a/tools/harness-deployment
+++ b/tools/harness-deployment
@@ -61,7 +61,8 @@ if __name__ == "__main__":
 
     root_paths = [os.path.join(os.getcwd(), path) for path in args.paths]
 
-    envs = (args.env.split("-") if "-" in args.env else [args.env])   if args.env else ()
+    envs = (args.env.split("-")
+            if "-" in args.env else [args.env]) if args.env else ()
 
     if unknown:
         print('There are unknown args. Make sure to call the script with the accepted args. Try --help')
@@ -90,17 +91,17 @@ if __name__ == "__main__":
             namespace=args.namespace
         )
 
-        root_paths = preprocess_build_overrides(root_paths=root_paths, helm_values=helm_values)
-
-        build_included = [app['harness']['name']
-                          for app in helm_values['apps'].values() if 'harness' in app]
+        root_paths = preprocess_build_overrides(
+            root_paths=root_paths, helm_values=helm_values)
 
         if envs:
-
-            create_codefresh_deployment_scripts(root_paths, include=build_included,
-                                                envs=envs,
-                                                base_image_name=helm_values['name'],
-                                                values_manual_deploy=helm_values)
+            create_codefresh_deployment_scripts(
+                root_paths,
+                include=args.include,
+                exclude=args.exclude,
+                envs=envs,
+                base_image_name=helm_values['name'],
+                values_manual_deploy=helm_values)
 
         create_skaffold_configuration(root_paths, helm_values)
         create_vscode_debug_configuration([os.path.join(os.getcwd(), path) for path in args.paths],

--- a/tools/tests/test_codefresh.py
+++ b/tools/tests/test_codefresh.py
@@ -149,7 +149,6 @@ def test_create_codefresh_configuration_multienv():
     for cmd in cf['steps']['prepare_deployment']['commands']:
         if 'harness-deployment' in cmd:
             assert '-e dev-test' in cmd
-            assert " . " in cmd
             assert "test_deployment" in cmd
             assert "-i samples" in cmd
     shutil.rmtree(BUILD_MERGE_DIR)

--- a/tools/tests/test_codefresh.py
+++ b/tools/tests/test_codefresh.py
@@ -149,4 +149,7 @@ def test_create_codefresh_configuration_multienv():
     for cmd in cf['steps']['prepare_deployment']['commands']:
         if 'harness-deployment' in cmd:
             assert '-e dev-test' in cmd
+            assert " . " in cmd
+            assert "test_deployment" in cmd
+            assert "-i samples" in cmd
     shutil.rmtree(BUILD_MERGE_DIR)


### PR DESCRIPTION
Closes #548 

Implemented solution: the command is now automatically generated by the script looking at the paths and included apps

How to test this PR: remove deployment-configuration/codefresh-dev.yaml from your solution and run harness-deployment ... -e dev. Check deployment/codefresh-dev.yaml to check that everything is ok

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [x] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
