### PR TITLE
#548 fix .overrides directory being included in cf

### DIFF
--- a/tools/cloudharness_utilities/codefresh.py
+++ b/tools/cloudharness_utilities/codefresh.py
@@ -237,7 +237,7 @@ def create_codefresh_deployment_scripts(root_paths, envs=(), include=(), exclude
         cmds[i] = cmds[i].replace("$ENV", "-".join(envs))
         cmds[i] = cmds[i].replace("$PARAMS", " ".join(params))
         cmds[i] = cmds[i].replace("$PATHS", " ".join(os.path.relpath(
-                                    root_path, '.') for root_path in root_paths))
+                                    root_path, '.') for root_path in root_paths if DEFAULT_MERGE_PATH not in root_path))
 
     if save:
         codefresh_abs_path = join(

--- a/tools/cloudharness_utilities/constants.py
+++ b/tools/cloudharness_utilities/constants.py
@@ -6,6 +6,7 @@ HERE = os.path.dirname(os.path.realpath(__file__)).replace(os.path.sep, '/')
 ROOT = os.path.dirname(HERE)
 
 APPLICATION_TEMPLATE_PATH = 'application-templates'
+DEFAULT_MERGE_PATH = ".overrides"
 
 HELM_PATH = "helm"
 HELM_CHART_PATH = HELM_PATH

--- a/tools/cloudharness_utilities/preprocessing.py
+++ b/tools/cloudharness_utilities/preprocessing.py
@@ -1,4 +1,3 @@
-from email.mime import base
 from genericpath import exists
 import os
 
@@ -9,12 +8,11 @@ from os.path import join, basename, isabs, relpath
 from cloudharness_utilities.helm import KEY_APPS, KEY_TASK_IMAGES
 
 from .utils import app_name_from_path, merge_app_directories, merge_configuration_directories, find_subdirs
-from .constants import APPS_PATH, HELM_CHART_PATH, DEPLOYMENT_CONFIGURATION_PATH, DEPLOYMENT_PATH, \
-    BASE_IMAGES_PATH, STATIC_IMAGES_PATH
+from .constants import APPS_PATH,BASE_IMAGES_PATH, STATIC_IMAGES_PATH, DEFAULT_MERGE_PATH
 
 
 
-def preprocess_build_overrides(root_paths, helm_values, merge_build_path=".overrides"):
+def preprocess_build_overrides(root_paths, helm_values, merge_build_path=DEFAULT_MERGE_PATH):
     if not isabs(merge_build_path):
         merge_build_path = join(os.getcwd(), merge_build_path)
     if len(root_paths) < 2:
@@ -73,7 +71,7 @@ def preprocess_build_overrides(root_paths, helm_values, merge_build_path=".overr
 
     return (root_paths + [merge_build_path]) if merged else root_paths
 
-def get_build_paths(root_paths, helm_values, merge_build_path=".overrides"):
+def get_build_paths(root_paths, helm_values, merge_build_path=DEFAULT_MERGE_PATH):
     """
     Gets the same paths from preprocess_build_overrides
     """


### PR DESCRIPTION
Fixes #548 regression with overriden files (dockerfile included)

Implemented solution: .overrides removed from the generated paths

How to test this PR: run harness-deployment ... -e dev in a deployment with overridden applications and check that .overrides is not included in the codefresh-dev.yaml file

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [ ] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
