### PR TITLE
#553 +Default allow option on gk

### DIFF
--- a/tools/cloudharness_utilities/deployment-configuration/helm/templates/auto-gatekeepers.yaml
+++ b/tools/cloudharness_utilities/deployment-configuration/helm/templates/auto-gatekeepers.yaml
@@ -15,6 +15,7 @@ data:
     client-secret: {{ .root.Values.apps.accounts.webclient.secret }}
     secure-cookie: {{ $tls }}
     forbidden-page: /templates/access-denied.html.tmpl
+    enable-default-deny:  {{ eq (.app.harness.secured | toString) "true" }}
     listen: 0.0.0.0:8080
     enable-refresh-tokens: true
     server-write-timeout: 60s


### PR DESCRIPTION
Closes #553 

Implemented solution: used a ternary logic -- truthy but not `true` are defaulting to default open gatekeeper

How to test this PR: configure an application with values.yaml like
```yaml
harness:
  secured: "open"
  uri_role_mapping:
  - uri: /admin/*
    roles:
    - admin
```

### Sanity checks:
- [ ] The pull request is explicitly linked to the relevant issue(s)
- [ ] The issue is well described: clearly states the problem and the general proposed solution(s)
- [ ] From the issue and the current PR it is explicitly stated how to test the current change
- [ ] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [ ] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [ ] All the linked issues are assigned

### Breaking changes (select one):
- [ ] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [ ] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
