### PR TITLE
#561 fix: add CSRF_TRUSTED_ORIGINS to fix CSRF admin issue

### DIFF
--- a/infrastructure/common-images/cloudharness-django/libraries/cloudharness-django/cloudharness_django/settings.py
+++ b/infrastructure/common-images/cloudharness-django/libraries/cloudharness-django/cloudharness_django/settings.py
@@ -5,7 +5,7 @@ from django.conf import settings
 # ***********************************************************************
 # * CloudHarness Django settings
 # ***********************************************************************
-from cloudharness.applications import get_current_configuration, log
+from cloudharness import applications, log
 
 # add the 3rd party apps
 INSTALLED_APPS = getattr(
@@ -33,7 +33,7 @@ MIDDLEWARE = getattr(
 # get the application CH config
 app_name = settings.PROJECT_NAME.lower()
 try:
-    current_app = get_current_configuration()
+    current_app = applications.get_current_configuration()
     
 
     # if secured then set USE_X_FORWARDED_HOST because we are behind the GK proxy
@@ -46,8 +46,7 @@ except:
     # we are running on a developers local machine
     log.error("Error setting current app configuration, continuing...", exc_info=True)
 
-    from cloudharness.applications import ApplicationConfiguration
-    current_app = ApplicationConfiguration({
+    current_app = applications.ApplicationConfiguration({
         "name": app_name,
         "harness": {
             "database": {

--- a/infrastructure/common-images/cloudharness-django/libraries/cloudharness-django/cloudharness_django/settings.py
+++ b/infrastructure/common-images/cloudharness-django/libraries/cloudharness-django/cloudharness_django/settings.py
@@ -44,7 +44,7 @@ try:
 except:
     # no current app found, fall back to the default settings, there is a god change that
     # we are running on a developers local machine
-    log.error("Error setting current app configuration, continuing...", exc_info=True)
+    log.warning("Error setting current app configuration, continuing...")
 
     current_app = applications.ApplicationConfiguration({
         "name": app_name,

--- a/infrastructure/common-images/cloudharness-django/libraries/cloudharness-django/cloudharness_django/settings.py
+++ b/infrastructure/common-images/cloudharness-django/libraries/cloudharness-django/cloudharness_django/settings.py
@@ -6,6 +6,7 @@ from django.conf import settings
 # * CloudHarness Django settings
 # ***********************************************************************
 from cloudharness import applications, log
+from cloudharness.utils.config import CloudharnessConfig as conf
 
 # add the 3rd party apps
 INSTALLED_APPS = getattr(
@@ -35,12 +36,15 @@ app_name = settings.PROJECT_NAME.lower()
 try:
     current_app = applications.get_current_configuration()
     
-
     # if secured then set USE_X_FORWARDED_HOST because we are behind the GK proxy
     USE_X_FORWARDED_HOST = current_app.harness.secured
     
-    # CSRF
-    CSRF_TRUSTED_ORIGINS = [current_app.get_public_address()]
+    # CSRF, set CSRF_TRUSTED_ORIGINS
+    CH_DOMAIN = conf.get_domain()
+    CSRF_TRUSTED_ORIGINS = getattr(
+        settings,
+        'CSRF_TRUSTED_ORIGINS',
+        []) + [f"https://{CH_DOMAIN}", f"https://*.{CH_DOMAIN}"]
 except:
     # no current app found, fall back to the default settings, there is a god change that
     # we are running on a developers local machine


### PR DESCRIPTION
Closes #561 

Implemented solution: add CSRF_TRUSTED_ORIGINS setting

How to test this PR: install a CH Django based app, go to the admin and create a new record. If no CSRF failure then everything is correct

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
