### PR TITLE
#563 fix: crashing openapi backend generator for route based params

### DIFF
--- a/tools/cloudharness_utilities/application-templates/django-app/api/templates/main.jinja2
+++ b/tools/cloudharness_utilities/application-templates/django-app/api/templates/main.jinja2
@@ -103,7 +103,8 @@ def {{operation.function_name}}({{operation.snake_case_arguments}}) -> {{operati
     return api_controller.{{operation.function_name}}(
     {% endif %}
     {% for params in operation.snake_case_arguments.split(",") -%}
-    {% if params %}{{params.split(":")[0]}}={{params.split(":")[0]}}{% if not loop.last %},{% endif %}{% endif %}
+    {% if params and ':' in params %}
+        {{params.split(":")[0]}}={{params.split(":")[0]}},
     {% endfor -%})
 {% endfor %}
 


### PR DESCRIPTION
Closes #563

Implemented solution: update the Jinja2 library to generate the correct function calls

How to test this PR: run genapi.sh on an openapi.yaml file

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
