### PR TITLE
Feature/516

### DIFF
--- a/libraries/cloudharness-common/cloudharness/applications.py
+++ b/libraries/cloudharness-common/cloudharness/applications.py
@@ -43,6 +43,9 @@ class ApplicationConfiguration(ApplicationConfig):
             database_name = kwargs.get('database_name', self.harness.database.postgres['initialdb'])
             return f"postgres://{self.db_name}:{self.harness.database.postgres.ports[0]['port']}/" \
                    f"{database_name}?user={self.harness.database.user}&password={self.harness.database['pass']}"
+        elif self.db_type == 'neo4j':
+            return f"{self.harness.database.neo4j.get('ports')[1]['name']}://{self.db_name}:" \
+                   f"{self.harness.database.neo4j.get('ports')[1]['port']}/"
         else:
             raise NotImplementedError(
                 f'Database connection string discovery not yet supported for database type {self.db_type}')

--- a/libraries/cloudharness-common/cloudharness/applications.py
+++ b/libraries/cloudharness-common/cloudharness/applications.py
@@ -33,20 +33,24 @@ class ApplicationConfiguration(ApplicationConfig):
     def is_sentry_enabled(self) -> bool:
         return self.harness.sentry
 
-    def get_db_connection_string(self) -> str:
+    def get_db_connection_string(self, **kwargs) -> str:
         if not self.is_auto_db():
             raise ConfigurationCallException(
                 f"Cannot get configuration string: application {self.name} has no database enabled.")
         if self.db_type == 'mongo':
             return f"mongodb://{self.harness.database.user}:{self.harness.database.password}@{self.db_name}:{self.harness.database.mongo.ports[0]['port']}/"
+        elif self.db_type == 'postgres':
+            database_name = kwargs.get('database_name', self.harness.database.postgres['initialdb'])
+            return f"postgres://{self.db_name}:{self.harness.database.postgres.ports[0]['port']}/" \
+                   f"{database_name}?user={self.harness.database.user}&password={self.harness.database['pass']}"
         else:
             raise NotImplementedError(
-                f'Database connection string discovery not yet supported for databse type {self.db_type}')
+                f'Database connection string discovery not yet supported for database type {self.db_type}')
 
     @property
     def db_name(self) -> str:
         return self.harness.database.name
-        
+
     @property
     def conf(self):
         """


### PR DESCRIPTION
Closes #516

Implemented solution: 
- Returns complete connection string for postgres databases
- Returns bolt uri for neo4j databases

How to test this PR: 
- Create a cloudharness based application with a database for each database type (postgres and neo4j)
- Request the connection string from ch:
```
app = applications.get_configuration('appName')
conn_string = app.get_db_connection_string()
```
- Use the connection string to connect, for example:
neo4j
```
self.driver = GraphDatabase.driver(uri, auth=(user, password))
```
postgres
```
conn = psycopg2.connect(conn_string)
```

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope
