### PR TITLE
#571 fix: added get_dependencies() call to generator methods to check & get the dependencies for openapi

### DIFF
--- a/tools/cloudharness_utilities/openapi.py
+++ b/tools/cloudharness_utilities/openapi.py
@@ -37,6 +37,7 @@ def generate_fastapi_server(app_path):
 
 
 def generate_model(base_path=ROOT):
+    get_dependencies()
     lib_path = f"{base_path}/libraries/models"
 
     # Generate model stuff: use python-flask generator
@@ -78,6 +79,7 @@ def generate_python_client(module, openapi_file, client_src_path, lib_name=LIB_N
 
 
 def generate_ts_client(openapi_file):
+    get_dependencies()
     config_path = os.path.join(os.path.dirname(openapi_file), 'config.json')
     out_dir = f"{os.path.dirname(os.path.dirname(openapi_file))}/frontend/src/rest"
     command = f"java -jar {CODEGEN} generate " \


### PR DESCRIPTION
Closes #571 

Implemented solution: ` added get_dependencies()`

How to test this PR: `harness-application -t webapp testapp`

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
