### PR TITLE
#573 default gk http-only-cookie false

### DIFF
--- a/tools/cloudharness_utilities/deployment-configuration/helm/templates/auto-gatekeepers.yaml
+++ b/tools/cloudharness_utilities/deployment-configuration/helm/templates/auto-gatekeepers.yaml
@@ -20,6 +20,7 @@ data:
     enable-refresh-tokens: true
     server-write-timeout: 60s
     upstream-response-header-timeout: 60s
+    http-only-cookie: false
     tls-cert:
     tls-private-key:
     redirection-url: {{ ternary "https" "http" $tls }}://{{ .app.harness.subdomain }}.{{ .root.Values.domain }}


### PR DESCRIPTION
Closes #573 

Implemented solution: changed the value in the auto-gatekeeper template 

How to test this PR: open a page with a gatekeeper and check in the chrome console if document.cookie has `kc-access`

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [x] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
