### PR TITLE
#577 fix codefresh issue with _: replace _ with __

### DIFF
--- a/tools/cloudharness_utilities/codefresh.py
+++ b/tools/cloudharness_utilities/codefresh.py
@@ -224,9 +224,9 @@ def create_codefresh_deployment_scripts(root_paths, envs=(), include=(), exclude
             for app_name, app in helm_values.apps.items():
                 if app.harness.secrets:
                     for secret in [secret[0] for secret in app.harness.secrets.items() if secret[1]]:
-                        secret_name = secret
+                        secret_name = secret.replace("_", "__")
                         arguments["custom_values"].append(
-                            "apps.%s.harness.secrets.%s=${{%s}}" % (app_name, secret_name, secret_name.upper()))
+                            "apps.%s.harness.secrets.%s=${{%s}}" % (app_name.replace("_", "__"), secret_name, secret_name.upper()))
 
     cmds = codefresh['steps']['prepare_deployment']['commands']
     

--- a/tools/cloudharness_utilities/codefresh.py
+++ b/tools/cloudharness_utilities/codefresh.py
@@ -226,7 +226,7 @@ def create_codefresh_deployment_scripts(root_paths, envs=(), include=(), exclude
                     for secret in [secret[0] for secret in app.harness.secrets.items() if secret[1]]:
                         secret_name = secret.replace("_", "__")
                         arguments["custom_values"].append(
-                            "apps.%s.harness.secrets.%s=${{%s}}" % (app_name.replace("_", "__"), secret_name, secret_name.upper()))
+                            "apps_%s_harness_secrets_%s=${{%s}}" % (app_name.replace("_", "__"), secret_name, secret_name.upper()))
 
     cmds = codefresh['steps']['prepare_deployment']['commands']
     


### PR DESCRIPTION
Closes #577

Implemented solution: : replaced with __ see https://codefresh.io/docs/docs/new-helm/using-helm-in-codefresh-pipeline/ -- "If a variable already contains a _ (underscore) in its name, replace it with __ (double underscore)."

How to test this PR: in a deployment with secrets check that _ custom values in the deployment step are replaced with __ like 

```
  deployment:
    stage: deploy
    type: helm
    working_directory: ./${{CF_REPO_NAME}}
    title: Installing chart
    arguments:
      helm_version: 3.6.2
      chart_name: deployment/helm
      release_name: '${{NAMESPACE}}'
      kube_context: '${{CLUSTER_NAME}}'
      namespace: '${{NAMESPACE}}'
      chart_version: '${{CF_BUILD_ID}}'
      cmd_ps: --wait --timeout 600s
      custom_value_files:
      - ./deployment/helm/values.yaml
      custom_values:
      - apps.mnp__checkout.harness.secrets.stripe-public-key=${{STRIPE-PUBLIC-KEY}}
      - apps.mnp__checkout.harness.secrets.stripe-private-key=${{STRIPE-PRIVATE-KEY}}
      - apps.mnp__checkout.harness.secrets.stripe-webhook-secret=${{STRIPE-WEBHOOK-SECRET}}
```

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
