### PR TITLE
Feature/498

### DIFF
--- a/tools/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
+++ b/tools/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
@@ -100,16 +100,18 @@ spec:
 ---
 {{ end }}
 {{- range $app := .Values.apps }}
-  {{- if and $app.harness.database $app.harness.database.auto  }}
-     {{ include "deploy_utils.database" (dict "root" $ "app" $app) }}
-  {{- end }}
-  {{- range $subapp := $app }}
-  {{- if contains "map" (typeOf $subapp)  }}
-  {{- if hasKey $subapp "harness"}}
-  {{- if and (hasKey $subapp.harness "database") $subapp.harness.database.auto }}
-      {{ include "deploy_utils.database" (dict "root" $ "app" $subapp) }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
+  {{- if  $app.harness.database  }}
+    {{- if $app.harness.database.auto  }}
+      {{ include "deploy_utils.database" (dict "root" $ "app" $app) }}
+    {{- end }}
+    {{- range $subapp := $app }}
+    {{- if contains "map" (typeOf $subapp)  }}
+    {{- if hasKey $subapp "harness"}}
+    {{- if and (hasKey $subapp.harness "database") $subapp.harness.database.auto }}
+        {{ include "deploy_utils.database" (dict "root" $ "app" $subapp) }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+ {{- end }}

--- a/tools/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
+++ b/tools/cloudharness_utilities/deployment-configuration/helm/templates/auto-database.yaml
@@ -100,7 +100,7 @@ spec:
 ---
 {{ end }}
 {{- range $app := .Values.apps }}
-  {{- if $app.harness.database.auto  }}
+  {{- if and $app.harness.database $app.harness.database.auto  }}
      {{ include "deploy_utils.database" (dict "root" $ "app" $app) }}
   {{- end }}
   {{- range $subapp := $app }}

--- a/tools/cloudharness_utilities/utils.py
+++ b/tools/cloudharness_utilities/utils.py
@@ -293,6 +293,9 @@ def dict_merge(dct, merge_dct, add_keys=True):
         dict: updated dict
     """
     dct = dct.copy()
+    if merge_dct is None:
+        return dct
+
     if not add_keys:
         merge_dct = {
             k: merge_dct[k]

--- a/tools/tests/resources/applications/myapp/deploy/values-withmongo.yaml
+++ b/tools/tests/resources/applications/myapp/deploy/values-withmongo.yaml
@@ -1,0 +1,4 @@
+harness:
+  database:
+    auto: true
+    type: mongo

--- a/tools/tests/resources/applications/myapp/deploy/values-withpostgres.yaml
+++ b/tools/tests/resources/applications/myapp/deploy/values-withpostgres.yaml
@@ -1,0 +1,2 @@
+harness:
+  database: {auto: true, type: postgres}


### PR DESCRIPTION
Closes #498

Implemented solution: 
The `helm.py` module, responsible for the helm chart generation, is modified to include a detection of unused DBs.
The `__clear_unused_db_configuration` contains the cleaning logic.
First, the used db is identified using the `type` property of the `database` entry of the current configuration.
All the DBs configurations are extracted relying on the fact that each DB entry always contains an `image` key and a `ports` key.
The DBs configurations that are not used in the project are deleted.

Writing tests I saw that even if I remove the entries from the helm_values during the process, some are added back by the HarnessMainConfig at the end.
This is not a problem for the deployment/values.yaml generation as the file generation is performed before the instance of HarnessMainConfig is created, but it looks weird anyway.

How to test this PR:

Some tests are integrated with the PR.
To test the PR, it is possible to generate an app for a dedicated DB and check in the `values.yaml` that there is no other entries.

The generation of the app: 
```
harness-application dbtest -t db-mongo
harness-deployment cloud-harness . -i dbtest

# then check if there is well mongo in values.yaml and nothing else
grep -i mongo deployment/helm/values.yaml

# and there is not the others entries
grep -i postgres deployment/helm/values.yaml
grep -i neo4j deployment/helm/values.yaml
```

### Sanity checks:
- [X] The pull request is explicitly linked to the relevant issue(s)
- [X] The issue is well described: clearly states the problem and the general proposed solution(s)
- [X] From the issue and the current PR it is explicitly stated how to test the current change
- [X] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [X] All the automated test checks are passing
- [X] All the linked issues are included in one milestone
- [X] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [X] All the linked issues are assigned

### Breaking changes (select one):
- [X] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [X] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [X] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [X] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
