### PR TITLE
Feature/587

### DIFF
--- a/applications/samples/backend/requirements.txt
+++ b/applications/samples/backend/requirements.txt
@@ -9,3 +9,4 @@ swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 Flask == 1.1.2
+httpx==0.23.0

--- a/libraries/cloudharness-common/requirements.txt
+++ b/libraries/cloudharness-common/requirements.txt
@@ -20,3 +20,4 @@ schemathesis==3.16.5
 hypothesis==6.54.2
 jsonschema==4.9.1
 openapi-spec-validator==0.3.1
+httpx==0.23.0

--- a/libraries/cloudharness-common/requirements.txt
+++ b/libraries/cloudharness-common/requirements.txt
@@ -3,11 +3,11 @@ certifi==2019.3.9
 chardet==3.0.4
 idna==2.8
 pyjwt>=1.7.1,<2
-pyOpenSSL==19.0.0
+pyOpenSSL==22.1.0
 PySocks==1.6.8
 requests>=2.27.0
-ruamel-yaml==0.16.13
-six==1.12.0
+ruamel.yaml==0.17.21
+six==1.16.0
 urllib3>=1.26
 pykafka==2.8.0
 pyaml
@@ -17,3 +17,6 @@ sentry-sdk[flask]==0.14.4
 python-keycloak==1.6.0
 argo-workflows==5.0.0
 schemathesis==3.16.5
+hypothesis==6.54.2
+jsonschema==4.9.1
+openapi-spec-validator==0.3.1

--- a/libraries/cloudharness-common/requirements.txt
+++ b/libraries/cloudharness-common/requirements.txt
@@ -16,4 +16,4 @@ kubernetes
 sentry-sdk[flask]==0.14.4
 python-keycloak==1.6.0
 argo-workflows==5.0.0
-schemathesis==3.15.4
+schemathesis==3.16.5

--- a/libraries/cloudharness-common/test-requirements.txt
+++ b/libraries/cloudharness-common/test-requirements.txt
@@ -5,6 +5,7 @@ py==1.11.0
 pyparsing==3.0.8
 pytest==7.1.2
 pytest-cov==3.0.0
+httpx==0.23.0
 -e .
 -e ../client/cloudharness_cli
 -e ../models

--- a/tools/test-requirements.txt
+++ b/tools/test-requirements.txt
@@ -6,4 +6,6 @@ pyparsing==3.0.8
 pytest==7.1.2
 pytest-cov==3.0.0
 -e ../libraries/models
+-e ../libraries/client/cloudharness_cli
+-e ../libraries/cloudharness-common
 -e .


### PR DESCRIPTION
Closes #587 

Implemented solution: 
- Adds httpx dependency where needed
- Fixes unittests pipeline error by adding ch dependencies to ch tools requirements
- Fixes harness test command errors by fixing problematic dependencies and achieve perfect balance

How to test this PR: 
- Run harness-test . locally:
![image](https://user-images.githubusercontent.com/19196034/194880706-1bca5048-bd8d-48fe-b141-63dde4f1acd2.png)

- See if codefresh pipelines pass

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope
