### PR TITLE
#595 fix: Fix main.jinja2 template

### DIFF
--- a/tools/cloudharness_utilities/application-templates/django-app/api/templates/main.jinja2
+++ b/tools/cloudharness_utilities/application-templates/django-app/api/templates/main.jinja2
@@ -90,7 +90,18 @@ PROTECTED = [Depends(has_access)]
 # Operations
 
 {% for operation in operations %}
-@prefix_router.{{operation.type}}('{{operation.snake_case_path}}', response_model={{operation.response}}, tags={{operation["tags"]}}{% if operation.security %}, dependencies=PROTECTED{% endif %})
+    @prefix_router.{{operation.type}}('{{operation.snake_case_path}}', response_model={{operation.response}}, tags={{operation["tags"]}}{% if operation.security %}, dependencies=PROTECTED{% endif %}
+    {% if operation.additional_responses %}
+        , responses={
+        {% for status_code, models in operation.additional_responses.items() %}
+            '{{ status_code }}': {
+            {% for key, model in models.items() %}
+                '{{ key }}': {{ model }}{% if not loop.last %},{% endif %}
+            {% endfor %}
+            }{% if not loop.last %},{% endif %}
+        {% endfor %}
+        }
+    {% endif %})
 def {{operation.function_name}}({{operation.snake_case_arguments}}) -> {{operation.response}}:
     {%- if operation.summary %}
     """


### PR DESCRIPTION
Closes #595 

Implemented solution: 
- Adds missing section to main.jinga2 template

How to test this PR: 
- Use an openapi specification with a multipart/form-data request body to generate the fastapi code
- Confirm there's a body on the parameter on the 'controller' generated

Tested manually on Natus:

<details>
  <summary>OpenApi Specification</summary>

```
  ---
  openapi: 3.0.2
  info:
    title: Natus HFO Tools
    version: 1.0.0
  servers:
    - url: /api
      description: ""
  paths:
    /live:
      get:
        tags:
          - test
        responses:
          "200":
            content:
              application/json:
                schema:
                  type: string
            description: Healthy
          "500":
            description: Application is not healthy
        operationId: live
        summary: Test if application is healthy
    /ready:
      get:
        tags:
          - test
        responses:
          "200":
            content:
              application/json:
                schema:
                  type: string
            description: Ready
          "500":
            description: Application is not ready
        operationId: ready
        summary: Test if application is ready
    /subjects:
      summary: Path used to manage the list of subjects.
      description: "The REST endpoint/path used to list and create zero or more `Subject`\
        \ entities.  This path contains a `GET` and `POST` operation to perform the\
        \ list and create tasks, respectively."
      get:
        tags:
          - crud
        parameters:
          - examples:
              first:
                value: "1"
            name: page
            description: "Represents the page requested, considering the size parameter"
            schema:
              type: integer
            in: query
          - examples:
              default:
                value: "10"
            name: size
            description: Corresponds to the cardinality of antibodies requested
            schema:
              type: integer
            in: query
          - name: search
            description: "Searches a `Subject` with the given name (case insensitive,\
            \ LIKE containment)"
            schema:
              type: string
            in: query
        responses:
          "200":
            content:
              application/json:
                schema:
                  type: array
                  items:
                    $ref: '#/components/schemas/Subject'
            description: Successful response - returns an array of `Subject` entities.
        operationId: getSubjects
        summary: List All Subjects
        description: Gets a list of all `Subject` entities.
      post:
        requestBody:
          description: A new `Subject` to be created.
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Subject'
          required: true
        tags:
          - crud
        responses:
          "201":
            description: Successful response.
        operationId: createSubject
        summary: Create a Subject
        description: Creates a new instance of a `Subject`.
    /jobs/{job_id}:
      summary: Path used to manage a single Job.
      description: "The REST endpoint/path used to get, update, and delete single instances\
        \ of an `Subject`.  This path contains `GET`, `PUT`, and `DELETE` operations\
        \ used to perform the get, update, and delete tasks, respectively."
      get:
        tags:
          - monitoring
        responses:
          "200":
            content:
              application/json:
                schema:
                  $ref: '#/components/schemas/Job'
            description: Successful response - returns a single `Job`.
        operationId: getJob
        summary: Get a Job
        description: Gets the details of a single instance of a `Subject`.
      delete:
        tags:
          - monitoring
        responses:
          "200":
            description: Deletion performed
        operationId: stopJob
        summary: Stops an ongoing job
      parameters:
        - name: job_id
          schema:
            type: integer
          in: path
          required: true
    /subjects/{subject_id}:
      summary: Path used to manage a single Subject.
      description: "The REST endpoint/path used to get, update, and delete single instances\
        \ of an `Subject`.  This path contains `GET`, `PUT`, and `DELETE` operations\
        \ used to perform the get, update, and delete tasks, respectively."
      get:
        tags:
          - crud
        responses:
          "200":
            content:
              application/json:
                schema:
                  $ref: '#/components/schemas/Subject'
            description: Successful response - returns a single `Subject`.
        operationId: getSubject
        summary: Get a Subject
        description: Gets the details of a single instance of a `Subject`.
      put:
        requestBody:
          description: Updated `Subject` information.
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Subject'
          required: true
        tags:
          - crud
        responses:
          "202":
            description: Successful response.
        operationId: updateSubject
        summary: Update a Subject
        description: Updates an existing `Subject`.
      delete:
        tags:
          - crud
        responses:
          "204":
            description: Successful response.
        operationId: deleteSubject
        summary: Delete a Subject
        description: Deletes an existing `Subject`.
      parameters:
        - name: subject_id
          description: A unique identifier for a `Subject`.
          schema:
            type: integer
          in: path
          required: true
    /subjects/{subject_id}/studies:
      summary: Path used to manage the list of subjects.
      description: The REST endpoint/path used to list and create zero or more `Study`
        entities.  This path contains a `POST` operation to perform the create task.
      post:
        requestBody:
          description: A new `Subject` to be created.
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Study'
          required: true
        tags:
          - crud
        responses:
          "201":
            description: Successful response.
        operationId: createStudy
        summary: Create a Study
        description: Adds a `Study` for the given `Subject`.
      parameters:
        - name: subject_id
          description: the subject the study belongs to
          schema:
            type: integer
          in: path
          required: true
    /subjects/{subject_id}/studies/{study_id}/mri:
      summary: Path used to manage the list of subjects.
      description: The REST endpoint/path used to upload a MRI file
      post:
        requestBody:
          description: A new MRI to be created.
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/UploadFile'
          required: true
        tags:
          - upload
        responses:
          "201":
            description: Successful response.
        operationId: uploadMRI
        summary: Create a Subject
        description: Uploads a `MRI` for the given `Study`.
      parameters:
        - name: subject_id
          description: the subject the study belongs to
          schema:
            type: integer
          in: path
          required: true
        - name: study_id
          description: the study to attack the MRI file to
          schema:
            type: integer
          in: path
          required: true
  components:
    schemas:
      Study:
        description: ""
        required:
          - name
        type: object
        properties:
          name:
            description: ""
            type: string
          id:
            description: ""
            type: integer
          status:
            description: Defines the general state of the study
            enum:
              - START
              - ONGOING
              - FINISHED
            type: string
          start:
            format: date-time
            description: start date of the `Study`
            type: string
          mri:
            $ref: '#/components/schemas/ClinicalFile'
            description: Original mri
          leftSurface:
            $ref: '#/components/schemas/ClinicalFile'
            description: ""
          rightSurface:
            $ref: '#/components/schemas/ClinicalFile'
            description: ""
          t1:
            $ref: '#/components/schemas/ClinicalFile'
            description: Preprocess mri at standard resolution
          labels:
            description: ""
            type: array
            items:
              $ref: '#/components/schemas/ClinicalFile'
          jobs:
            description: All relevant jobs related to this study.
            type: array
            items:
              $ref: '#/components/schemas/Job'
      Subject:
        description: ""
        required:
          - name
        type: object
        properties:
          name:
            description: ""
            type: string
          id:
            description: ""
            type: integer
          responsibleId:
            description: Responsible user id
            type: string
          studies:
            description: ""
            type: array
            items:
              $ref: '#/components/schemas/Study'
      ClinicalFile:
        description: ""
        required:
          - type
          - path
        type: object
        properties:
          type:
            description: ""
            enum:
              - NIFTI
              - DICOM
              - MESH
            type: string
          path:
            description: The download path for the file
            type: string
          name:
            description: ""
            type: string
      Job:
        description: Describes a batch/asynchronous process
        required:
          - type
          - id
          - start
        type: object
        properties:
          type:
            description: ""
            enum:
              - MRI_PROCESSING
              - MRI_CT_ALIGNMENT
              - ELECTRODE_EXTRACTION
            type: string
          start:
            format: date-time
            description: ""
            type: string
          status:
            description: ""
            enum:
              - QUEUE
              - RUNNING
              - ERROR
              - COMPLETED
            type: string
          id:
            description: ""
            type: string
      UploadFile:
        description: The file binary content
        required:
          - binary
        type: object
        properties:
          binary:
            format: binary
            description: ""
            type: string
    securitySchemes:
      cookieAuth:
        type: apiKey
        name: kc-access
        in: cookie
        x-apikeyInfoFunc: cloudharness.auth.decode_token
      bearerAuth:
        scheme: bearer
        bearerFormat: JWT
        type: http
        x-bearerInfoFunc: cloudharness.auth.decode_token
  tags:
    - name: crud
      description: ""
    - name: upload
      description: ""
    - name: monitoring
      description: ""
    - name: test
      description: ""

```
</details>

<details>
  <summary>Relevant generated code </summary>
  
```
@prefix_router.post(
    '/subjects/{subject_id}/studies/{study_id}/mri',
    response_model=None,
    tags=['upload'],
)
def upload_m_r_i(subject_id: int, study_id: int = ..., body: UploadFile = ...) -> None:
    """
    Create a Subject
    """
    return upload_controller.upload_m_r_i(
        subject_id=subject_id,
        study_id=study_id,
        body=body,
    )
```
  
</details>

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [ ] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope
