### PR TITLE
#630 feat: Add workflow name to on exit event

### DIFF
--- a/applications/workflows/tasks/notify-queue/main.py
+++ b/applications/workflows/tasks/notify-queue/main.py
@@ -1,12 +1,14 @@
 import sys
+import os
 import logging
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
-assert len(sys.argv) > 3, 'Not all arguments not specified. Cannot notify queue. Usage: [workflow status] [queue name] [payload]'
+assert len(
+    sys.argv) > 3, 'Not all arguments not specified. Cannot notify queue. Usage: [workflow status] [queue name] [payload]'
 
 from cloudharness.workflows.utils import notify_queue
 
 queue = sys.argv[2]
-message = {'status': sys.argv[1], 'payload': sys.argv[3]}
+message = {'status': sys.argv[1], 'payload': sys.argv[3], 'workflow': os.getenv('CH_WORKFLOW_NAME')}
 notify_queue(queue, message)


### PR DESCRIPTION
Closes #630

Implemented solution: 
- Adds workflow name to on exit message

How to test this PR: 
- Run a workflow and verify if the message appears with the workflow name

![image](https://user-images.githubusercontent.com/19196034/203039489-db927b1b-636d-4e78-aa51-b06015573239.png)


### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [ ] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope
