### PR TITLE
#632 feat: add switch to retrieve group attributes

### DIFF
--- a/libraries/cloudharness-common/cloudharness/auth/keycloak.py
+++ b/libraries/cloudharness-common/cloudharness/auth/keycloak.py
@@ -250,13 +250,13 @@ class AuthClient():
         return True
 
     @with_refreshtoken
-    def get_group(self, group_id, with_members=False, brief_representation=False) -> UserGroup:
+    def get_group(self, group_id, with_members=False, brief_representation=True) -> UserGroup:
         """
         Return the group in the application realm
         
         :param group_id: the group id to get
         :param with_members: Default False, when set to True all members of the group are also retrieved
-        :param brief_representation: Default False, when set to True all attributes of the group are also retrieved
+        :param brief_representation: Default True, when set to False all attributes of the group are also retrieved
 
 
         GroupRepresentation
@@ -374,12 +374,12 @@ class AuthClient():
         return admin_client.group_user_remove(user_id, group_id)
 
     @with_refreshtoken
-    def get_users(self, query=None, brief_representation=False) -> List[User]:
+    def get_users(self, query=None, brief_representation=True) -> List[User]:
         """
         Return a list of all users in the application realm
         
         :param query: Default None, the query filter for getting the users
-        :param brief_representation: Default False, when set to True all attributes of the group are also retrieved
+        :param brief_representation: Default True, when set to True all attributes of the group are also retrieved
 
         UserRepresentation
         https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_userrepresentation
@@ -401,12 +401,12 @@ class AuthClient():
         return users
 
     @with_refreshtoken
-    def get_user(self, user_id, brief_representation=False):
+    def get_user(self, user_id, brief_representation=True):
         """
         Get the user including the user groups
 
         :param user_id: User id
-        :param brief_representation: Default False, when set to True all attributes of the group are also retrieved
+        :param brief_representation: Default True, when set to False all attributes of the group are also retrieved
 
 
         UserRepresentation

--- a/libraries/cloudharness-common/cloudharness/auth/keycloak.py
+++ b/libraries/cloudharness-common/cloudharness/auth/keycloak.py
@@ -379,7 +379,7 @@ class AuthClient():
         Return a list of all users in the application realm
         
         :param query: Default None, the query filter for getting the users
-        :param brief_representation: Default True, when set to True all attributes of the group are also retrieved
+        :param brief_representation: Default True, when set to False all attributes of the group are also retrieved
 
         UserRepresentation
         https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_userrepresentation

--- a/libraries/cloudharness-common/cloudharness/auth/keycloak.py
+++ b/libraries/cloudharness-common/cloudharness/auth/keycloak.py
@@ -250,13 +250,13 @@ class AuthClient():
         return True
 
     @with_refreshtoken
-    def get_group(self, group_id, with_members=False, brief_representation=True) -> UserGroup:
+    def get_group(self, group_id, with_members=False, with_details=False) -> UserGroup:
         """
         Return the group in the application realm
         
         :param group_id: the group id to get
         :param with_members: Default False, when set to True all members of the group are also retrieved
-        :param brief_representation: Default True, when set to False all attributes of the group are also retrieved
+        :param with_details: Default False, when set to True all attributes of the group are also retrieved
 
 
         GroupRepresentation
@@ -271,7 +271,7 @@ class AuthClient():
             members = admin_client.get_group_members(group_id)
             for user in members:
                 user.update(
-                    {'userGroups': admin_client.get_user_groups(user['id'], brief_representation=brief_representation)})
+                    {'userGroups': admin_client.get_user_groups(user['id'], brief_representation=not with_details)})
                 user.update(
                     {'realmRoles': admin_client.get_realm_roles_of_user(user['id'])})
             group.update({'members': members})
@@ -374,12 +374,12 @@ class AuthClient():
         return admin_client.group_user_remove(user_id, group_id)
 
     @with_refreshtoken
-    def get_users(self, query=None, brief_representation=True) -> List[User]:
+    def get_users(self, query=None, with_details=False) -> List[User]:
         """
         Return a list of all users in the application realm
         
         :param query: Default None, the query filter for getting the users
-        :param brief_representation: Default True, when set to False all attributes of the group are also retrieved
+        :param with_details: Default False, when set to True all attributes of the group are also retrieved
 
         UserRepresentation
         https://www.keycloak.org/docs-api/16.0/rest-api/index.html#_userrepresentation
@@ -394,19 +394,19 @@ class AuthClient():
         users = []
         for user in admin_client.get_users(query=query):
             user.update({
-                "userGroups": admin_client.get_user_groups(user['id'], brief_representation=brief_representation),
+                "userGroups": admin_client.get_user_groups(user['id'], brief_representation=not with_details),
                 'realmRoles': admin_client.get_realm_roles_of_user(user['id'])
                 })
             users.append(User.from_dict(user))
         return users
 
     @with_refreshtoken
-    def get_user(self, user_id, brief_representation=True):
+    def get_user(self, user_id, with_details=False):
         """
         Get the user including the user groups
 
         :param user_id: User id
-        :param brief_representation: Default True, when set to False all attributes of the group are also retrieved
+        :param with_details: Default False, when set to True all attributes of the group are also retrieved
 
 
         UserRepresentation
@@ -420,7 +420,7 @@ class AuthClient():
         admin_client = self.get_admin_client()
         user = admin_client.get_user(user_id)
         user.update({
-                "userGroups": admin_client.get_user_groups(user_id=user['id'], brief_representation=brief_representation),
+                "userGroups": admin_client.get_user_groups(user_id=user['id'], brief_representation=not with_details),
                 'realmRoles': admin_client.get_realm_roles_of_user(user['id'])
                 })
         return User.from_dict(user)


### PR DESCRIPTION
Closes #632 

Implemented solution: added param `brief_representation` (default True) to the get user / get group , to retrieve the group details (incl. the attributes) set the param to False 

How to test this PR: 
```python
from cloudharness.auth.keycloak import AuthClient
ac=AuthClient()
ac.get_users(brief_representation=False)
```

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x ] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [x] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
