### PR TITLE
#628 justMyCode added

### DIFF
--- a/tools/deployment-cli-tools/ch_cli_tools/skaffold.py
+++ b/tools/deployment-cli-tools/ch_cli_tools/skaffold.py
@@ -203,18 +203,13 @@ def create_vscode_debug_configuration(root_paths, helm_values):
             if app_key in apps.keys():
                 debug_conf["debug"].append({
                     "image": get_image_tag(app_name),
-                    # the double source map doesn't work at the moment. Hopefully will be fixed in future skaffold updates
                     "sourceFileMap": {
+                        "justMyCode": False,
                         f"${{workspaceFolder}}/{app_relative_to_root}": apps[app_key].harness.get('sourceRoot',
                                                                                                        "/usr/src/app"),
                     }
                 })
-                debug_conf["debug"].append({
-                    "image": get_image_tag(app_name),
-                    "sourceFileMap": {
-                        "${workspaceFolder}/cloud-harness/libraries": "/libraries"
-                    }
-                })
+                
 
     if not os.path.exists(os.path.dirname(vscode_launch_path)):
         os.makedirs(os.path.dirname(vscode_launch_path))


### PR DESCRIPTION
Closes #628 

Implemented solution: added justMyCode=False flag to vscode debug configuration

How to test this PR: debug with vscode and put a breakpoint on library code.

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
