### PR TITLE
#635 feat: add user defined exception for use for general pod spawn errors

### DIFF
--- a/applications/jupyterhub/src/harness_jupyter/harness_jupyter/jupyterhub.py
+++ b/applications/jupyterhub/src/harness_jupyter/harness_jupyter/jupyterhub.py
@@ -8,6 +8,10 @@ handler = logging.StreamHandler(sys.stdout)
 handler.setLevel(logging.DEBUG)
 logging.getLogger().addHandler(handler)
 
+class PodSpawnException(Exception):
+    pass
+
+
 def harness_hub():
     """Wraps the method to change spawner configuration"""
     KubeSpawner.get_pod_manifest_base = KubeSpawner.get_pod_manifest
@@ -127,5 +131,7 @@ def change_pod_manifest(self: KubeSpawner):
                             f(self=self)
                     break
 
+    except TooManyPodsException as e:
+        raise e
     except Exception as e:
         logging.error("Harness error changing manifest", exc_info=True)


### PR DESCRIPTION
Closes #635 

Implemented solution: added a "generic" Pod Spawn Exception to CH jupyterhub.py that is catched and raised again instead of the generic catch all log and continue exception

How to test this PR: 
- import PodSpawnException from harness_jupyter jupyterhub
- raise this exception

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
