### PR TITLE
#657 chore: add support for auto pulling CloudHarness tasks onto JupyterHub nodes with the JH prepuller

### DIFF
--- a/applications/jupyterhub/README.md
+++ b/applications/jupyterhub/README.md
@@ -23,3 +23,11 @@ harness:
           values: pool-highcpu   # k8s highcpu instance pool
           matchPurpose: require  # require | prefer | ignore
 ```
+
+## Customizations
+
+CloudHarness pre puller of tasks images support
+To support the pre pulling of task images see (https://github.com/MetaCell/cloud-harness/issues/657)
+the template `templates/image-puller/_helpers-daemonset.tpl` has been changed (see line 167 and on)
+
+TODO: remember to implement/revise this code after you have updated/changed the templates of JupyterHub

--- a/applications/jupyterhub/deploy/templates/image-puller/_helpers-daemonset.tpl
+++ b/applications/jupyterhub/deploy/templates/image-puller/_helpers-daemonset.tpl
@@ -165,6 +165,24 @@ spec:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
         {{- end }}
+
+        {{- /* --- Pull CloudHarness tasks images --- */}}
+        {{- range $k, $v := ( index .Values "task-images" )  }}
+        - name: image-pull-{{ $k | replace "-" "" }}
+          image: {{ $v }}
+          command:
+            - /bin/sh
+            - -c
+            - echo "Pulling complete"
+          {{- with $.Values.apps.jupyterhub.prePuller.resources }}
+          resources:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.apps.jupyterhub.prePuller.containerSecurityContext }}
+          securityContext:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+        {{- end }}
       containers:
         - name: pause
           image: {{ .Values.apps.jupyterhub.prePuller.pause.image.name }}:{{ .Values.apps.jupyterhub.prePuller.pause.image.tag }}


### PR DESCRIPTION
Closes #657 

Implemented solution: add loop over CH tasks to pre puller helper template

How to test this PR: run the deployment (helm) in dry-run debug mode and check the generated output JH image puller extraImages 

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
