### PR TITLE
Doc/tutorial update

### DIFF
--- a/docs/tutorials/cloud-harness-wsl2-setup.md
+++ b/docs/tutorials/cloud-harness-wsl2-setup.md
@@ -1,0 +1,70 @@
+
+### The first thing to check
+
+> Make sure you have JDK installed in your WSL system. Without this, the code is not generated! (with harness-application command). A bunch of errors that I had was solved by this step. In addition, test if you have all the basic requirements needed for the Cloud-Harness + other requirements needed to set up.
+
+Please check if you are running **Kubernetes with Docker Desktop.**
+
+If you have Codecloud VS extension, make sure to check that you have docker-desktop ACTIVE. You can also check the namespace which by default is set to `default`
+
+### Setting namespaces and with `docker-desktop` context
+
+> The commands related to minikube from the tutorial are not needed in the case of docker-desktop.
+
+We create namespaces inside docker-desktop… for our case of following the tutorial, it is azathoth
+
+```
+kubectl create ns azathoth
+```
+
+If want to change the namespace while keeping the context same (i.e. docker-desktop) then the following is the command. This is because the default namespace is `default`
+
+```
+kubectl config set-context --current --namespace=azathoth
+```
+
+### Deployment command distinction
+
+Use the following command when you want your application installed inside the cloud-harness directory (very less likely; that one would use this)
+
+```
+harness-deployment . -u -dtls -l -d azathoth.local -e local -n azathoth
+```
+
+Otherwise (mostly how we use it)
+
+```
+harness-deployment cloud-harness . -u -dtls -l -d azathoth.local -e local -n azathoth
+```
+
+### About host file issue
+
+To be able to visit links like - [http://clockdate.azathoth.local/](http://clockdate.azathoth.local/), or [http://clockdate.azathoth.local/api/ping](http://clockdate.azathoth.local/api/ping), we need to update the host file. Make note that the host file is of Windows (and not for the subsystem), which can be found here:
+
+```
+C:\Windows\System32\drivers\etc\hosts
+```
+
+(NOTE: We might be able to work with Linux hosts if we enable - *_Add the .docker.internal names to the host's etc/hosts file (Requires password)_ in the General settings of docker desktop. But I haven’t tested that. )
+
+### If Running CLOUD HARNESS for the first time!
+
+There are certain scripts that need to be run when running the CloudHarness and its dependent applications for the first time in a system. These are `sc.yaml` and `cluster-init.sh` which can be found in the following path w.r.t. cloud-harness.
+
+```
+kubectl apply -f cloudharness/deployment/sc.yaml
+```
+
+```
+cd cloud-harness/infrastructure/cluster-configuration && bash cluster-init.sh
+```
+
+These are one-time setup scripts needed to be run.
+
+### About Frontend issues
+
+If the [clockdate.azathoth.local](http://clockdate.azathoth.local/) doesn’t return the frontend part!
+
+When the frontend is generated through the “harness-application”, the package-lock.json is required which is not mentioned in the docs. Therefore one must have to do the `npm i —legacy-peer-deps` before proceeding with the “scaffold run” command.
+
+

--- a/docs/tutorials/simple-date-clock-application.adoc
+++ b/docs/tutorials/simple-date-clock-application.adoc
@@ -307,6 +307,8 @@ The file tree should now be the following.
 
 Now you can build/deploy/run it using `skaffold`.
 
+Before running `skaffold run` go inside the newly created application using harness-application; and make sure the frontend for the application contains package-lock.json. If not then install the dependencies by running `npm i --legacy-peer-deps`.
+
 .Building/deploying/running the webapp with skaffold
 [source,bash]
 ----

--- a/docs/tutorials/simple-date-clock-application.adoc
+++ b/docs/tutorials/simple-date-clock-application.adoc
@@ -71,6 +71,7 @@ If everything is good, you're in the right path to use {ch}!
 
 == How to setup your local cluster using minikube (if not done yet)
 
+
 {ch} is designed to help you generate all the required artifacts for a deployment on a Kubernetes cluster.
 For a local deployment, you can use minikube, which is basically https://minikube.sigs.k8s.io/docs/start/[a small {kub} cluster on your machine].
 
@@ -147,7 +148,7 @@ If you don't create the namespace, the deployment will fail!
 [source,bash]
 ----
 # ran from the cloud-harness repository root
-harness-deployment  . -u -dtls -l -d azathoth.local -e local -n azathoth.local
+harness-deployment  . -u -dtls -l -d azathoth.local -e local -n azathoth
 ----
 
 In the state of the repository I have on my machine, the apps and services that will be deployed and that `harness-deployment` generated the configuration for are:

--- a/docs/tutorials/simple-date-clock-application.adoc
+++ b/docs/tutorials/simple-date-clock-application.adoc
@@ -77,7 +77,7 @@ For a local deployment, you can use minikube, which is basically https://minikub
 
 
 [IMPORTANT - WSL2]
-If following this tutorial in a Windows WSL2 - then check https://stackoverflowteams.com/c/metacell/questions/84/[this] for help!
+If you're following this tutorial in a Windows WSL2 - then check =>  link:./cloud-harness-wsl2-setup.md[cloud-harness-wsl2-setup] for help!
 
 
 [IMPORTANT]

--- a/docs/tutorials/simple-date-clock-application.adoc
+++ b/docs/tutorials/simple-date-clock-application.adoc
@@ -75,6 +75,11 @@ If everything is good, you're in the right path to use {ch}!
 {ch} is designed to help you generate all the required artifacts for a deployment on a Kubernetes cluster.
 For a local deployment, you can use minikube, which is basically https://minikube.sigs.k8s.io/docs/start/[a small {kub} cluster on your machine].
 
+
+[IMPORTANT - WSL2]
+If following this tutorial in a Windows WSL2 - then check https://stackoverflowteams.com/c/metacell/questions/84/[this] for help!
+
+
 [IMPORTANT]
 The setup of a {kub} cluster is not mandatory to use {ch}.
 This step is proposed in this tutorial to show you how to deploy an application generated with {ch} on a local cluster and to appreciate how much {ch} reduces the pain of writing deployment configuration artifacts.


### PR DESCRIPTION
Closes - None (A doc tutorial update)

Implemented solution: Changed the doc to include or change
- Changed the namespace name error 
- Added a package-lock.json possible error
- Added a WSL2 reference link to stackoverflow question

How to test this PR: Read the file changed i.e. at path - /docs/tutorials/simple-date-clock-application.adoc

### Sanity checks:
- [ ] The pull request is explicitly linked to the relevant issue(s)
- [ ] The issue is well described: clearly states the problem and the general proposed solution(s)
- [ ] From the issue and the current PR it is explicitly stated how to test the current change
- [ ] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [ ] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [ ] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [x] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
