### PR TITLE
Feature/707

### DIFF
--- a/deployment-configuration/helm/templates/auto-database.yaml
+++ b/deployment-configuration/helm/templates/auto-database.yaml
@@ -74,11 +74,6 @@ spec:
         volumeMounts:
           - name: {{ .app.harness.database.name | quote }}
             mountPath: /data/db
-          {{- if .root.Values.backup.active }}
-          - name: "db-backups"
-            mountPath: {{ (printf "%s/%s/%s" .root.Values.backup.dir .app.harness.database.type .app.harness.database.name) | quote }}
-            readOnly: true
-          {{- end }}
           {{- if eq .app.harness.database.type "postgres" }}
           - mountPath: /dev/shm
             name: dshm  
@@ -92,11 +87,6 @@ spec:
           medium: Memory
         name: dshm     
       {{- end }}     
-      {{- if .root.Values.backup.active }}
-      - name: "db-backups"
-        persistentVolumeClaim:
-          claimName: "db-backups"
-      {{- end }}
 ---
 {{- if .root.Values.backup.active }}
 {{- include (print "deploy_utils.database." .app.harness.database.type ".backup") . }}


### PR DESCRIPTION
Closes #707

Implemented solution: the volume has been removed from the deployment

How to test this PR: set `backups: true` in the values-template.yaml and verify that the db-backups volume is not mounted to the database pod.

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [x] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
