### PR TITLE
Git clone functionality fixes

### DIFF
--- a/docs/applications/dependencies.md
+++ b/docs/applications/dependencies.md
@@ -70,6 +70,7 @@ harness:
       branch_tag: v1.0.0
       path: myrepo
 ```
+> Note that the path parameter is optional and its use should be restricted to necessity (e.g. name clashes)
 
 The directory structure will be as following:
 ```
@@ -84,8 +85,11 @@ Hence, inside the Dockerfile we expect to see something like
 
 ```dockerfile
 COPY dependencies .
-COPY dependencies/b.git/src .
-COPY dependencies/myrepo .
+```
+or
+```dockerfile
+COPY dependencies/b/src .
+COPY dependencies/myrepo/b .
 ```
 
 > Note that Cloud Harness does not add the COPY/ADD statements to the Dockerfile

--- a/tools/deployment-cli-tools/ch_cli_tools/codefresh.py
+++ b/tools/deployment-cli-tools/ch_cli_tools/codefresh.py
@@ -51,7 +51,7 @@ def clone_step_spec(conf: GitDependencyConfig, context_path: str):
         "type": "git-clone",
         "repo": conf.url,
         "revision": conf.branch_tag,
-        "working_directory": join(context_path, "dependencies", conf.path or os.path.basename(conf.url)),
+        "working_directory": join(context_path, "dependencies", conf.path or ""),
         "git": get_main_domain(conf.url) # Cannot really tell what's the git config name, usually the name of the repo
     }
 
@@ -176,7 +176,7 @@ def create_codefresh_deployment_scripts(root_paths, envs=(), include=(), exclude
 
                     if app_config and app_config.dependencies and app_config.dependencies.git:
                         for dep in app_config.dependencies.git:
-                            steps[CD_BUILD_STEP_DEPENDENCIES]['steps'].append(clone_step_spec(dep, base_path))
+                            steps[CD_BUILD_STEP_DEPENDENCIES]['steps'].append(clone_step_spec(dep, dockerfile_relative_to_root))
 
                     build = None
                     if build_step in steps:

--- a/tools/deployment-cli-tools/ch_cli_tools/skaffold.py
+++ b/tools/deployment-cli-tools/ch_cli_tools/skaffold.py
@@ -12,6 +12,8 @@ from .helm import KEY_APPS, KEY_HARNESS, KEY_DEPLOYMENT, KEY_TASK_IMAGES
 from .utils import get_template, dict_merge, find_dockerfiles_paths, app_name_from_path, \
     find_file_paths, guess_build_dependencies_from_dockerfile, merge_to_yaml_file, get_json_template, get_image_name
 
+from . import HERE
+
 def relpath_if(p1, p2):
     if os.path.isabs(p1):
         return p1
@@ -198,10 +200,10 @@ def git_clone_hook(conf: GitDependencyConfig, context_path: str):
     return {
         'command': [
             'sh',
-            'tools/clone.sh',
+            join(os.path.dirname(os.path.dirname(HERE)), 'clone.sh'),
             conf.branch_tag,
             conf.url,
-            join(context_path, "dependencies", conf.path or os.path.basename(conf.url))   
+            join(context_path, "dependencies", conf.path or os.path.basename(conf.url).split('.')[0])   
         ]
     }
 


### PR DESCRIPTION
Follows up from #720, relates to CH-37

The paths were not correctly relativized when used inside a top level app.
Also codefresh paths needed fix.

Implemented solution: fixed paths

How to test this PR: same as #720 

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [x] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [x] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
