### PR TITLE
Update node version

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -93,7 +93,6 @@ This file is part of the CloudHarness runtime.
 Other constants are located there as shown in the following code extract.
 
 ```python
-NODE_BUILD_IMAGE = 'node:8.16.1-alpine'
 APPLICATION_TEMPLATE_PATH = 'application-templates'
 # ...
 APPS_PATH = 'applications'

--- a/infrastructure/base-images/cloudharness-frontend-build/Dockerfile
+++ b/infrastructure/base-images/cloudharness-frontend-build/Dockerfile
@@ -1,3 +1,3 @@
-FROM node:15.5
+FROM node:20
 
 

--- a/libraries/cloudharness-utils/cloudharness_utils/constants.py
+++ b/libraries/cloudharness-utils/cloudharness_utils/constants.py
@@ -1,9 +1,5 @@
 import os
 
-NODE_BUILD_IMAGE = 'node:8.16.1-alpine'
-
-
-
 APPLICATION_TEMPLATE_PATH = 'application-templates'
 DEFAULT_MERGE_PATH = ".overrides"
 

--- a/test/test-e2e/Dockerfile
+++ b/test/test-e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-slim
+FROM node:20
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer


### PR DESCRIPTION
Closes CH-118

Implemented solution: The version has been updated in the CLOUDHARNESS_FRONTEND_BUILD image, which should be used a a dependency to build other node applications.

How to test this PR: Automated tests are enough here as the some images won't build if the image is not found

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [ ] All the linked issues are in the Review state
- [ ] All the linked issues are assigned

### Breaking changes (select one):
- [ ] The present changes do not change the preexisting api in any way
- [x] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [x] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
