### PR TITLE
CH-123 add parameters to Sentry init

### DIFF
--- a/libraries/cloudharness-common/cloudharness/sentry/__init__.py
+++ b/libraries/cloudharness-common/cloudharness/sentry/__init__.py
@@ -2,6 +2,7 @@ import os
 import requests
 
 from cloudharness.utils.env import get_common_service_cluster_address
+from cloudharness.applications import get_current_configuration
 
 sentry_environment = os.environ.get("DOMAIN", "Production")
 
@@ -29,32 +30,39 @@ def get_dsn(appname):
     else:
         return None
 
-def init(appname, traces_sample_rate=0):
+def init(appname=None, traces_sample_rate=0, integrations=None, **kwargs):
     """
     Init cloudharness Sentry functionality for the current app
 
     Args:
         appname: the slug of the application
-        traces_sample_rate: performance trace sample rate
+        others/kwargs: additional parameters for sentry_sdk.init
+
 
     Usage examples: 
         import cloudharness.sentry as sentry
         sentry.init('notifications')
     """
+    if appname is None:
+        appname = get_current_configuration().harness.name
+
     dsn = get_dsn(appname)
+
     if dsn:
         import sentry_sdk
-        try:
-            from flask import current_app as app
-            from sentry_sdk.integrations.flask import FlaskIntegration
-            integrations = [FlaskIntegration()]
-        except:
-            integrations = []
+        if not integrations:
+            try:
+                from flask import current_app as app
+                from sentry_sdk.integrations.flask import FlaskIntegration
+                integrations = [FlaskIntegration()]
+            except:
+                integrations = []
         sentry_sdk.init(
             dsn=dsn,
-            traces_sample_rate=traces_sample_rate,
             environment=sentry_environment,
-            integrations=integrations
+            integrations=integrations,
+            traces_sample_rate=traces_sample_rate,
+            **kwargs
         )
 
 __all__ = ['get_dsn', 'init']


### PR DESCRIPTION
Closes CH-123

Implemented solution: changed cloudharness api to pass through sentry_sdk parameters 

How to test this PR: testing on a project (ask @filippomc)

### Sanity checks:
- [ ] The pull request is explicitly linked to the relevant issue(s)
- [ ] The issue is well described: clearly states the problem and the general proposed solution(s)
- [ ] From the issue and the current PR it is explicitly stated how to test the current change
- [ ] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [ ] All the linked issues are in the Review/QA column of the [board](https://app.zenhub.com/workspaces/cloud-harness-5fdb203b7e195b0015a273d7/board)
- [ ] All the linked issues are assigned

### Breaking changes (select one):
- [ ] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [ ] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope


