### PR TITLE
CH-124 add forwarded headers configuration

### DIFF
--- a/deployment-configuration/helm/templates/ingress.yaml
+++ b/deployment-configuration/helm/templates/ingress.yaml
@@ -45,6 +45,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-keepalive-timeout: {{ .Values.proxy.timeout.keepalive | quote }}
     nginx.ingress.kubernetes.io/proxy-read-timeout: {{ .Values.proxy.timeout.read | quote }}
     nginx.ingress.kubernetes.io/proxy-send-timeout: {{ .Values.proxy.timeout.send | quote }}
+    nginx.ingress.kubernetes.io/use-forwarded-headers: {{ .Values.proxy.forwardedHeaders | quote }}
 spec:
   rules:
   {{- range $app := .Values.apps }}

--- a/deployment-configuration/helm/values.yaml
+++ b/deployment-configuration/helm/values.yaml
@@ -68,7 +68,7 @@ backup:
       # -- K8s cpu resource definition.
       cpu: "50m"
 proxy:
-  # -- Set to false to hide remote client headers 
+  # -- Set to false to hide remote client headers. Will hide the client IPs in all logs
   forwardedHeaders: true
   timeout:
     # -- Timeout for proxy connections in seconds.

--- a/deployment-configuration/helm/values.yaml
+++ b/deployment-configuration/helm/values.yaml
@@ -68,6 +68,8 @@ backup:
       # -- K8s cpu resource definition.
       cpu: "50m"
 proxy:
+  # -- Set to false to hide remote client headers 
+  forwardedHeaders: true
   timeout:
     # -- Timeout for proxy connections in seconds.
     send: 60

--- a/docs/ingress-domains-proxies.md
+++ b/docs/ingress-domains-proxies.md
@@ -53,6 +53,8 @@ To configure it, override the following values in your `deployment-configuration
 
 ```yaml
 proxy:
+  # -- Set to false to hide remote client headers. Will hide the client IPs in all logs
+  forwardedHeaders: true
   timeout:
     # -- Timeout for proxy connections in seconds.
     send: 60


### PR DESCRIPTION
Closes [CH-124](https://metacell.atlassian.net/browse/CH-124)

Implemented solution: added `use-forwarded-headers` annotation to the ingress default template.

How to test this PR: deploy anche check that `use-forwarded-headers` is set in the cloudharness-ingress Ingress

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] All the automated test checks are passing
- [x] All the linked issues are included in one release
- [x] All the linked issues are in review state
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [x] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif


[CH-124]: https://metacell.atlassian.net/browse/CH-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ