### PR TITLE
Fix typer dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 -e libraries/models
 -e libraries/cloudharness-utils
 -e tools/deployment-cli-tools
-
+colorama<0.5.0,>=0.4.3
+typer==0.11.0

--- a/tools/deployment-cli-tools/ch_cli_tools/codefresh.py
+++ b/tools/deployment-cli-tools/ch_cli_tools/codefresh.py
@@ -261,10 +261,11 @@ def create_codefresh_deployment_scripts(root_paths, envs=(), include=(), exclude
                         image=image_tag_with_variables(app_name, tag, base_image_name),
                     )
 
-            codefresh_steps_from_base_path(join(root_path, BASE_IMAGES_PATH), CD_BUILD_STEP_BASE,
-                                           fixed_context=relpath(root_path, os.getcwd()), include=helm_values[KEY_TASK_IMAGES].keys())
-            codefresh_steps_from_base_path(join(root_path, STATIC_IMAGES_PATH), CD_BUILD_STEP_STATIC,
-                                            include=helm_values[KEY_TASK_IMAGES].keys())
+            if helm_values[KEY_TASK_IMAGES]:
+                codefresh_steps_from_base_path(join(root_path, BASE_IMAGES_PATH), CD_BUILD_STEP_BASE,
+                                               fixed_context=relpath(root_path, os.getcwd()), include=helm_values[KEY_TASK_IMAGES].keys())
+                codefresh_steps_from_base_path(join(root_path, STATIC_IMAGES_PATH), CD_BUILD_STEP_STATIC,
+                                                include=helm_values[KEY_TASK_IMAGES].keys())
 
             codefresh_steps_from_base_path(join(
                 root_path, APPS_PATH), CD_BUILD_STEP_PARALLEL)


### PR DESCRIPTION
Closes [CH-130](https://metacell.atlassian.net/browse/CH-130)

# Implemented solution

The typer dependency has been pinned to 0.11.0

# How to test this PR

On a clean virtual env, run
```
bash install.sh
harness-deployment 
```

The test pipeline is also covering this

# Sanity checks:
- [ ] The pull request is explicitly linked to the relevant issue(s)
- [ ] The issue is well described: clearly states the problem and the general proposed solution(s)
- [ ] In this PR it is explicitly stated how to test the current change
- [ ] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] The relevant components are indicated in the issue (if any)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one Sprint
- [ ] All the linked issues are in the Review state
- [ ] All the linked issues are assigned

# Breaking changes (select one):
- [ ] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change` and the migration procedure is well described [above](#implemented-solution)

# Possible deployment updates issues (select one):
- [ ] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

