### PR TITLE
CH-144 Add 10 minute timeout to skaffold template

### DIFF
--- a/deployment-configuration/skaffold-template.yaml
+++ b/deployment-configuration/skaffold-template.yaml
@@ -13,6 +13,8 @@ deploy:
     flags:
       upgrade:
         - --install
+      install:
+        - --timeout=10m
     releases:
     - name: null
       chartPath: deployment/helm

--- a/tools/deployment-cli-tools/tests/test_skaffold.py
+++ b/tools/deployment-cli-tools/tests/test_skaffold.py
@@ -104,6 +104,10 @@ def test_create_skaffold_configuration():
 
     assert len(sk['test'][1]['custom']) == 2
 
+    flags = sk['deploy']['helm']['flags']
+    assert '--timeout=10m' in flags['install']
+    assert '--install' in flags['upgrade']
+
     shutil.rmtree(OUT)
     shutil.rmtree(BUILD_DIR)
 


### PR DESCRIPTION
Closes [CH-144](https://metacell.atlassian.net/browse/CH-144)

Added a new flag to the deploy/helm/flags/install array of the skaffold template

... 

Unit tests added to the `test_skaffold.py` file in `ch_cli_tools`, any `skaffold.yaml` generated with `harness-deployment` should include a `--timeout=10m` flag in the deploy/helm/flags/install array.

...

# Sanity checks:
- [ ] The pull request is explicitly linked to the relevant issue(s)
- [ ] The issue is well described: clearly states the problem and the general proposed solution(s)
- [ ] In this PR it is explicitly stated how to test the current change
- [ ] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] The relevant components are indicated in the issue (if any)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one Sprint
- [ ] All the linked issues are in the Review state
- [ ] All the linked issues are assigned

# Breaking changes (select one):
- [ ] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change` and the migration procedure is well described [above](#implemented-solution)

# Possible deployment updates issues (select one):
- [ ] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
