### PR TITLE
CH-137 Add namespace to usesvolume labels and pod affinity selectors

### DIFF
--- a/deployment-configuration/helm/templates/auto-database.yaml
+++ b/deployment-configuration/helm/templates/auto-database.yaml
@@ -54,11 +54,6 @@ spec:
                     operator: In
                     values:
                       - {{ .app.harness.database.name }}-{{ .root.Values.namespace }}
-            - labelSelector:
-                matchExpressions:
-                  - key: usesvolume
-                    operator: In
-                    values:
                       - {{ .app.harness.database.name }} # Obsolete, kept for backwards compatability, to be removed at a later date
               topologyKey: "kubernetes.io/hostname"
       containers:

--- a/deployment-configuration/helm/templates/auto-database.yaml
+++ b/deployment-configuration/helm/templates/auto-database.yaml
@@ -32,7 +32,7 @@ metadata:
   name: {{ .app.harness.database.name | quote }}
   namespace: {{ .root.Values.namespace }}
   labels:
-    usesvolume: {{ .app.harness.database.name }}
+    usesvolume: {{ .app.harness.database.name }}-{{ .root.Values.namespace }}
 spec:
   replicas: 1
   selector:
@@ -43,7 +43,7 @@ spec:
       labels:
         app: {{ .app.harness.database.name | quote }}
         service: db
-        usesvolume: {{ .app.harness.database.name }}
+        usesvolume: {{ .app.harness.database.name }}-{{ .root.Values.namespace }}
     spec:
       affinity:
         podAffinity:
@@ -53,7 +53,7 @@ spec:
                   - key: usesvolume
                     operator: In
                     values:
-                      - {{ .app.harness.database.name }}
+                      - {{ .app.harness.database.name }}-{{ .root.Values.namespace }}
               topologyKey: "kubernetes.io/hostname"
       containers:
       - name: {{ .app.harness.database.name | quote }}

--- a/deployment-configuration/helm/templates/auto-database.yaml
+++ b/deployment-configuration/helm/templates/auto-database.yaml
@@ -53,8 +53,13 @@ spec:
                   - key: usesvolume
                     operator: In
                     values:
-                      - {{ .app.harness.database.name }} # Obsolete, kept for backwards compatability, to be removed at a later date
                       - {{ .app.harness.database.name }}-{{ .root.Values.namespace }}
+            - labelSelector:
+                matchExpressions:
+                  - key: usesvolume
+                    operator: In
+                    values:
+                      - {{ .app.harness.database.name }} # Obsolete, kept for backwards compatability, to be removed at a later date
               topologyKey: "kubernetes.io/hostname"
       containers:
       - name: {{ .app.harness.database.name | quote }}

--- a/deployment-configuration/helm/templates/auto-database.yaml
+++ b/deployment-configuration/helm/templates/auto-database.yaml
@@ -53,6 +53,7 @@ spec:
                   - key: usesvolume
                     operator: In
                     values:
+                      - {{ .app.harness.database.name }} # Obsolete, kept for backwards compatability, to be removed at a later date
                       - {{ .app.harness.database.name }}-{{ .root.Values.namespace }}
               topologyKey: "kubernetes.io/hostname"
       containers:

--- a/deployment-configuration/helm/templates/auto-deployments.yaml
+++ b/deployment-configuration/helm/templates/auto-deployments.yaml
@@ -45,12 +45,7 @@ spec:
                     operator: In
                     values:
                       - {{ .app.harness.deployment.volume.name }}-{{ .root.Values.namespace }}
-            - labelSelector:
-                matchExpressions:
-                  - key: usesvolume
-                    operator: In
-                    values:
-                      - {{ .app.harness.database.name }} # Obsolete, kept for backwards compatability, to be removed at a later date
+                      - {{ .app.harness.deployment.volume.name }} # Obsolete, kept for backwards compatability, to be removed at a later date
               topologyKey: "kubernetes.io/hostname"
       {{- end }}
       {{- end }}

--- a/deployment-configuration/helm/templates/auto-deployments.yaml
+++ b/deployment-configuration/helm/templates/auto-deployments.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: {{ .app.harness.deployment.name| quote }}
     {{- if .app.harness.deployment.volume }}
-    usesvolume: {{ .app.harness.deployment.volume.name }}
+    usesvolume: {{ .app.harness.deployment.volume.name }}-{{ .root.Values.namespace }}
     {{- end }}
 {{- include "deploy_utils.labels" .root | indent 4 }}
 spec:
@@ -26,7 +26,7 @@ spec:
       labels:
         app: {{ .app.harness.deployment.name| quote }}
         {{- if .app.harness.deployment.volume }}
-        usesvolume: {{ .app.harness.deployment.volume.name }}
+        usesvolume: {{ .app.harness.deployment.volume.name }}-{{ .root.Values.namespace }}
         {{- end }}
 {{- include "deploy_utils.labels" .root | indent 8 }}
     spec:
@@ -44,7 +44,7 @@ spec:
                   - key: usesvolume
                     operator: In
                     values:
-                      - {{ .app.harness.deployment.volume.name }}
+                      - {{ .app.harness.deployment.volume.name }}-{{ .root.Values.namespace }}
               topologyKey: "kubernetes.io/hostname"
       {{- end }}
       {{- end }}

--- a/deployment-configuration/helm/templates/auto-deployments.yaml
+++ b/deployment-configuration/helm/templates/auto-deployments.yaml
@@ -44,6 +44,7 @@ spec:
                   - key: usesvolume
                     operator: In
                     values:
+                      - {{ .app.harness.deployment.volume.name }} # Obsolete, kept for backwards compatability, to be removed at a later date
                       - {{ .app.harness.deployment.volume.name }}-{{ .root.Values.namespace }}
               topologyKey: "kubernetes.io/hostname"
       {{- end }}

--- a/deployment-configuration/helm/templates/auto-deployments.yaml
+++ b/deployment-configuration/helm/templates/auto-deployments.yaml
@@ -44,8 +44,13 @@ spec:
                   - key: usesvolume
                     operator: In
                     values:
-                      - {{ .app.harness.deployment.volume.name }} # Obsolete, kept for backwards compatability, to be removed at a later date
                       - {{ .app.harness.deployment.volume.name }}-{{ .root.Values.namespace }}
+            - labelSelector:
+                matchExpressions:
+                  - key: usesvolume
+                    operator: In
+                    values:
+                      - {{ .app.harness.database.name }} # Obsolete, kept for backwards compatability, to be removed at a later date
               topologyKey: "kubernetes.io/hostname"
       {{- end }}
       {{- end }}


### PR DESCRIPTION
Closes [CH-137](https://metacell.atlassian.net/browse/CH-137)

Added the namespace to the `usesvolume` labels and pod affinity label selectors.

... 

Run
`harness-deployment . -i samples -n <whatever>`

Move to `deployment/helm` and run
`helm template --debug . > tmp.yaml`

`tmp.yaml` should show that the `usesvolume` labels and selectors will have `-<whatever>` appended.

...

# Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] In this PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] The relevant components are indicated in the issue (if any)
- [ ] All the automated test checks are passing
- [x] All the linked issues are included in one Sprint
- [x] All the linked issues are in the Review state
- [x] All the linked issues are assigned

# Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change` and the migration procedure is well described [above](#implemented-solution)

# Possible deployment updates issues (select one):
- [ ] There is no reason why deployments based on CloudHarness may break after the current update
- [x] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif


[CH-137]: https://metacell.atlassian.net/browse/CH-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ