### PR TITLE
CH-45 Update django main file template to handle both auth header and cookie

### DIFF
--- a/application-templates/django-app/api/templates/main.jinja2
+++ b/application-templates/django-app/api/templates/main.jinja2
@@ -49,13 +49,17 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-from cloudharness.middleware import set_authentication_token
+from cloudharness.middleware import set_authentication_token, get_authentication_token
 @app.middleware("http")
 async def add_process_time_header(request: Request, call_next):
     # retrieve the bearer token from the header
     # and save it for use in the AuthClient
-    authorization = request.headers.get('Authorization')
+    authorization = request.headers.get('Authorization') or request.cookies.get('kc-access')
+
     if authorization:
+        if 'Bearer ' in authorization:
+            authorization = authorization.split('Bearer ')[1]
+
         set_authentication_token(authorization)
 
     return await call_next(request)
@@ -67,16 +71,17 @@ if os.environ.get('KUBERNETES_SERVICE_HOST', None):
     # start the kafka event listener when running in/for k8s
     import cloudharness_django.services.events
 
-# enable the Bearer Authentication
-security = HTTPBearer()
-
-async def has_access(credentials: HTTPBasicCredentials = Depends(security)):
+async def has_access():
     """
     Function that is used to validate the token in the case that it requires it
     """
     if not os.environ.get('KUBERNETES_SERVICE_HOST', None):
         return {}
-    token = credentials.credentials
+
+    token = get_authentication_token()
+
+    if not token:
+        raise HTTPException(status_code=401)
 
     try:
         payload = get_auth_service().get_auth_client().decode_token(token)

--- a/application-templates/webapp/frontend/src/App.tsx
+++ b/application-templates/webapp/frontend/src/App.tsx
@@ -3,14 +3,14 @@ import Version from './components/Version';
 
 
 const Main = () => (
-    <>
-      <img src="/logo.png" width="800" />
-      <h1>__APP_NAME__ React application is working!</h1>
-      <Version />
-      <RestTest />
-      <p>See api documentation <a href="/api/ui/">here</a></p>
-    </>
-  )
+  <>
+    <img src="/logo.png" width="800" />
+    <h1>__APP_NAME__ React application is working!</h1>
+    <Version />
+    <RestTest />
+    <p>See api documentation <a href="/api/ui/">here</a></p>
+  </>
+)
 
 
 export default Main;

--- a/application-templates/webapp/frontend/vite.config.ts
+++ b/application-templates/webapp/frontend/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
 
   const theDomain = env && env.DOMAIN ? env.DOMAIN : 'localhost:5000';
-  
+
   console.log('Dev server address: ', theDomain);
 
   const proxyTarget = theDomain;
@@ -22,21 +22,23 @@ export default defineConfig(({ mode }) => {
 
 
   return {
-  plugins: [react()],
-  server: {
-    port: 9000,
-    proxy: {
-      '/api/': {
-        target: replaceHost( proxyTarget, 'samples'),
-        secure: false,
-        changeOrigin: true,
-      },
-      '/proxy/common/api': {
-        target: replaceHost( proxyTarget, 'common'),
-        secure: false,
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/proxy\/common\/api/, '/api')
+    plugins: [react()],
+    server: {
+      port: 9000,
+      proxy: {
+        '/api/': {
+          target: replaceHost(proxyTarget, 'samples'),
+          secure: false,
+          changeOrigin: true,
+        },
+        '/proxy/common/api': {
+          target: replaceHost(proxyTarget, 'common'),
+          secure: false,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/proxy\/common\/api/, '/api')
+        }
       }
+    }
   }
-}}}
+}
 )


### PR DESCRIPTION
Closes [CH-45](https://metacell.atlassian.net/browse/CH-45)

Updated django main template to handle both auth header and auth cookie as well as fix some linting issues

... 

Use `harness-application` to create a new django application and run `genapi.sh` inside the created `api` folder

...

# Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] In this PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] The relevant components are indicated in the issue (if any)
- [ ] All the automated test checks are passing
- [x] All the linked issues are included in one Sprint
- [x] All the linked issues are in the Review state
- [ ] All the linked issues are assigned

# Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change` and the migration procedure is well described [above](#implemented-solution)

# Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif


[CH-45]: https://metacell.atlassian.net/browse/CH-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ