### PR TITLE
CH-163 Gatekeeper version update

### DIFF
--- a/deployment-configuration/helm/templates/auto-gatekeepers.yaml
+++ b/deployment-configuration/helm/templates/auto-gatekeepers.yaml
@@ -1,6 +1,18 @@
 {{/* Secured Services/Deployments */}}
+
+{{- define "check_no_wildcard_uri" -}}
+{{- $check := true -}}
+{{- range .uri_role_mapping -}}
+  {{- if eq .uri "/*" -}}
+    {{- $check = false -}}
+  {{- end -}}
+{{- end -}}
+{{- $check -}}
+{{- end -}}
+
 {{- define "deploy_utils.securedservice" }}
 {{- $tls := not (not .root.Values.tls) }}
+{{- $noWildcards := include "check_no_wildcard_uri" (dict "uri_role_mapping" .app.harness.uri_role_mapping) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -15,7 +27,7 @@ data:
     client-secret: {{ .root.Values.apps.accounts.webclient.secret }}
     secure-cookie: {{ $tls }}
     forbidden-page: /templates/access-denied.html.tmpl
-    enable-default-deny:  {{ eq (.app.harness.secured | toString) "true" }}
+    enable-default-deny: {{ $noWildcards }}
     listen: 0.0.0.0:8080
     enable-refresh-tokens: true
     server-write-timeout: {{ .app.harness.proxy.timeout.send | default .root.Values.proxy.timeout.send | default 180 }}s
@@ -115,7 +127,7 @@ spec:
 {{ include "deploy_utils.etcHosts" .root | indent 6 }}
       containers:
       - name: {{ .app.harness.service.name | quote }}
-        image: "quay.io/gogatekeeper/gatekeeper:1.3.8"
+        image: "quay.io/gogatekeeper/gatekeeper:2.14.3"
         imagePullPolicy: IfNotPresent
         {{ if .root.Values.local }}
         securityContext:


### PR DESCRIPTION
Closes [CH-163](https://metacell.atlassian.net/browse/CH-163)

# Implemented solution

Updated the gogatekeeper image from 1.3.8 to 2.14.3.
A small teak was necessary because `enable-default-deny: true` is not allowed anymore when "/*" rule is set

# How to test this PR

Can be tested from the test depoyment

# Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] In this PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] The relevant components are indicated in the issue (if any)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one Sprint
- [x] All the linked issues are in the Review state
- [x] All the linked issues are assigned

# Breaking changes (select one):
- [ ] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change` and the migration procedure is well described [above](#implemented-solution)

# Possible deployment updates issues (select one):
- [ ] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif


[CH-163]: https://metacell.atlassian.net/browse/CH-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ