### PR TITLE
CH-182 add default toleration to all workflows

### DIFF
--- a/libraries/cloudharness-common/cloudharness/workflows/operations.py
+++ b/libraries/cloudharness-common/cloudharness/workflows/operations.py
@@ -2,6 +2,8 @@ import time
 from collections.abc import Iterable
 from typing import List, Union
 
+import argo.workflows
+import argo.workflows.client
 import yaml
 
 from cloudharness import log
@@ -10,6 +12,7 @@ from cloudharness.utils import env, config
 from . import argo
 from .tasks import Task, SendResultTask, CustomTask
 from .utils import PodExecutionContext, affinity_spec, is_accounts_present, name_from_path, volume_mount_template
+import argo
 
 POLLING_WAIT_SECONDS = 1
 SERVICE_ACCOUNT = 'argo-workflows'
@@ -120,6 +123,7 @@ class ContainerizedOperation(ManagedOperation):
             'entrypoint': self.entrypoint,
             'ttlStrategy': self.ttl_strategy,
             'templates': [self.modify_template(template) for template in self.templates],
+            'tolerations': [argo.workflows.client.V1Toleration(key='cloudharness/temporary-job', operator='Equal', value='true').to_dict()],
             'serviceAccountName': SERVICE_ACCOUNT,
             'imagePullSecrets': [{'name': config.CloudharnessConfig.get_registry_secret()}],
             'volumes': [{

--- a/libraries/cloudharness-common/tests/test_workflow.py
+++ b/libraries/cloudharness-common/tests/test_workflow.py
@@ -122,6 +122,10 @@ def test_single_task_shared():
     accounts_offset = 1 if is_accounts_present() else 0
     assert len(op.volumes) == 1
     assert len(wf['spec']['volumes']) == 2 + accounts_offset
+    assert wf['spec']['tolerations'], "Tolerations should be added to the workflow"
+    assert wf['spec']['tolerations'][0]['key'] == 'cloudharness/temporary-job'
+    assert wf['spec']['tolerations'][0]['operator'] == 'Equal'
+    assert wf['spec']['tolerations'][0]['value'] == 'true'
     assert wf['spec']['volumes'][1 + accounts_offset]['persistentVolumeClaim']['claimName'] == 'myclaim'
     if accounts_offset == 1:
         assert wf['spec']['volumes'][1]['secret']['secretName'] == 'accounts'


### PR DESCRIPTION
Closes [CH-182](https://metacell.atlassian.net/browse/CH-182)

# Implemented solution

Added a default toleration to all workflows

# How to test this PR

Run a workflow and check if a toleration named `cloudharness/temporary-job` are set on the pod

# Sanity checks:
- [ ] The pull request is explicitly linked to the relevant issue(s)
- [ ] The issue is well described: clearly states the problem and the general proposed solution(s)
- [ ] In this PR it is explicitly stated how to test the current change
- [ ] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] The relevant components are indicated in the issue (if any)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one Sprint
- [ ] All the linked issues are in the Review state
- [ ] All the linked issues are assigned

# Breaking changes (select one):
- [ ] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change` and the migration procedure is well described [above](#implemented-solution)

# Possible deployment updates issues (select one):
- [ ] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
