### PR TITLE
CH-221 fix: Use kc_id instead of inconsistent kc_username or kc_email for user sync

### DIFF
--- a/applications/jupyterhub/src/harness_jupyter/harness_jupyter/jupyterhub.py
+++ b/applications/jupyterhub/src/harness_jupyter/harness_jupyter/jupyterhub.py
@@ -73,6 +73,7 @@ def affinity_spec(key, value):
         'topologyKey': 'kubernetes.io/hostname'
     }
 
+
 def affinity_preferred_spec(key, value, topology_key='kubernetes.io/hostname', operator='In'):
     """
     Generates a Kubernetes preferred affinity term.

--- a/infrastructure/common-images/cloudharness-django/libraries/cloudharness-django/cloudharness_django/services/user.py
+++ b/infrastructure/common-images/cloudharness-django/libraries/cloudharness-django/cloudharness_django/services/user.py
@@ -109,11 +109,6 @@ class UserService:
             member, created = Member.objects.get_or_create(user=user)
             member.kc_id = kc_user["id"]
             member.save()
-        else:
-            # Update existing user - ensure member record is consistent
-            member, created = Member.objects.get_or_create(user=user)
-            member.kc_id = kc_user["id"]
-            member.save()
 
         user = self._map_kc_user(user, kc_user, is_superuser, delete)
         user.save()

--- a/infrastructure/common-images/cloudharness-django/libraries/cloudharness-django/cloudharness_django/services/user.py
+++ b/infrastructure/common-images/cloudharness-django/libraries/cloudharness-django/cloudharness_django/services/user.py
@@ -100,7 +100,7 @@ class UserService:
 
         # First try to find existing user by kc_id
         user = get_user_by_kc_id(kc_user["id"])
-        
+
         if not user:
             # Create new user if doesn't exist
             username = kc_user.get("username", kc_user["email"])
@@ -114,7 +114,7 @@ class UserService:
             member, created = Member.objects.get_or_create(user=user)
             member.kc_id = kc_user["id"]
             member.save()
-        
+
         user = self._map_kc_user(user, kc_user, is_superuser, delete)
         user.save()
         return user
@@ -125,7 +125,7 @@ class UserService:
         if not user:
             # User doesn't exist, skip group sync
             return
-        
+
         user_groups = []
         for kc_group in kc_user["userGroups"]:
             user_groups += [Group.objects.get(name=kc_group["name"])]


### PR DESCRIPTION


Closes https://metacell.atlassian.net/browse/CH-221

# Implemented solution
 User.objects.get(username=kc_user["email"]) was trying to find users by email but searching the username field, causing User.DoesNotExist errors when Keycloak username ≠ email.
 
This PR replaces it with get_user_by_kc_id(kc_user["id"]) which uses the reliable Keycloak ID for lookup.

# How to test this PR

Sync keycloak users with Django users with at least 1 user where kc username differs from kc email.

# Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] In this PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] The relevant components are indicated in the issue (if any)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one Sprint
- [x] All the linked issues are in the Review state
- [x] All the linked issues are assigned

# Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change` and the migration procedure is well described [above](#implemented-solution)

# Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope
