### PR TITLE
SA-314 Enable user events by default in accounts deployments

### DIFF
--- a/applications/accounts/deploy/values.yaml
+++ b/applications/accounts/deploy/values.yaml
@@ -86,7 +86,7 @@ admin:
   user: admin
   role: administrator
 editUsernameAllowed: true
-useEvents: false
+useEvents: true
 identityProviders:
 - github
 - google

--- a/tools/deployment-cli-tools/ch_cli_tools/configurationgenerator.py
+++ b/tools/deployment-cli-tools/ch_cli_tools/configurationgenerator.py
@@ -328,17 +328,17 @@ class ConfigurationGenerator(object, metaclass=abc.ABCMeta):
             logging.info(f"Ignoring {ignore}")
             tag = generate_tag_from_content(build_context_path, ignore)
             logging.info(f"Content hash: {tag}")
-            
+
             # Get dependencies from build context if not provided
             dependencies = dependencies or guess_build_dependencies_from_dockerfile(build_context_path)
-            
+
             # Combine with dependency tags
             dep_tags = "".join(self.all_images.get(n, '') for n in dependencies)
             if dep_tags:
                 logging.info(f"Dependency tags: {[(n, self.all_images.get(n, '')) for n in dependencies]}")
             tag = sha1((tag + dep_tags).encode("utf-8")).hexdigest()
             logging.info(f"Generated tag (with dependencies): {tag}")
-            
+
             app_name = image_name.split("/")[-1]  # the image name can have a prefix
             self.all_images[app_name] = tag
         return self.registry + image_name + (f':{tag}' if tag else '')


### PR DESCRIPTION
Closes [SA-314](https://metacell.atlassian.net/browse/SA-314)

# Implemented solution

Enable user events by default to log security audit events.

# How to test this PR

Deploy a new accounts instance and verify that events are enabled.

# Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] In this PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] The relevant components are indicated in the issue (if any)
- [ ] All the automated test checks are passing
- [x] All the linked issues are included in one Sprint
- [x] All the linked issues are in the Review state
- [x] All the linked issues are assigned

# Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change` and the migration procedure is well described [above](#implemented-solution)

# Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif


[SA-314]: https://metacell.atlassian.net/browse/SA-314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ