### PR TITLE
CH-242 add user cache

### DIFF
--- a/infrastructure/common-images/cloudharness-django/libraries/cloudharness-django/cloudharness_django/middleware.py
+++ b/infrastructure/common-images/cloudharness-django/libraries/cloudharness-django/cloudharness_django/middleware.py
@@ -4,6 +4,8 @@ import jwt
 from django.contrib.auth.models import User
 from django.contrib.auth import logout
 from django.db import transaction
+from django.core.cache import cache
+from django.conf import settings
 from keycloak.exceptions import KeycloakGetError
 
 from cloudharness.auth.exceptions import InvalidToken
@@ -12,6 +14,9 @@ from .models import Member
 from cloudharness import log
 from cloudharness.auth.keycloak import AuthClient, User as KcUser, get_authentication_token
 from psycopg2.errors import UniqueViolation
+
+
+USER_CACHE_TTL = getattr(settings, "BEARER_TOKEN_USER_CACHE_TTL", 60)
 
 
 def _get_user(kc_user_id: str) -> User:
@@ -108,7 +113,7 @@ class BearerTokenMiddleware:
 
     @transaction.atomic
     def __call__(self, request):
-        user = getattr(request, "user", None)
+
         authentication_token = get_authentication_token()
         if not authentication_token or authentication_token == 'Bearer undefined':
             return self.get_response(request)
@@ -121,6 +126,16 @@ class BearerTokenMiddleware:
             response.delete_cookie('kc-access')
             return response
 
+        if kc_user_id:
+            cache_key = f"bearer_token_user:{kc_user_id}"
+            cached_user = cache.get(cache_key)
+            if cached_user:
+                request.user = cached_user
+                request._cached_user = cached_user
+                return self.get_response(request)
+
+        user = getattr(request, "user", None)
+
         if kc_user:
             if not user or user.is_anonymous or getattr(user, "member", None) is None or user.member.kc_id != kc_user_id:
                 user = _get_user(kc_user_id)
@@ -132,6 +147,7 @@ class BearerTokenMiddleware:
                         # Safe to assign - user has a valid Member
                         request.user = user
                         request._cached_user = user
+
                     except:
                         # This should NEVER happen due to _get_user safety checks,
                         # but if it does, DO NOT assign the user - keep anonymous
@@ -140,7 +156,8 @@ class BearerTokenMiddleware:
                         # Don't assign user - request will remain anonymous
         # elif not request.path.startswith('/admin/'):
         #     logout(request)
-
+        if kc_user_id:
+            cache.set(cache_key, user, timeout=USER_CACHE_TTL)
         return self.get_response(request)
 
 


### PR DESCRIPTION
Closes [CH-242](https://metacell.atlassian.net/browse/CH-242)

# Implemented solution

Added cache in the middleware right after keycloak token check

# How to test this PR

...

# Sanity checks:
- [ ] The pull request is explicitly linked to the relevant issue(s)
- [ ] The issue is well described: clearly states the problem and the general proposed solution(s)
- [ ] In this PR it is explicitly stated how to test the current change
- [ ] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] The relevant components are indicated in the issue (if any)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one Sprint
- [ ] All the linked issues are in the Review state
- [ ] All the linked issues are assigned

# Breaking changes (select one):
- [ ] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change` and the migration procedure is well described [above](#implemented-solution)

# Possible deployment updates issues (select one):
- [ ] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif


[CH-242]: https://metacell.atlassian.net/browse/CH-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ