### PR TITLE
CH-224: Gatekeeper update

### DIFF
--- a/deployment-configuration/helm/templates/auto-gatekeepers.yaml
+++ b/deployment-configuration/helm/templates/auto-gatekeepers.yaml
@@ -27,6 +27,8 @@ data:
     forbidden-page: /templates/access-denied.html.tmpl
     enable-default-deny: {{ $noWildcards }}
     listen: 0.0.0.0:8080
+    enable-encrypted-token: false
+    encryption-key: {{ .app.harness.secrets.gatekeeper | default (randAlphaNum 20) | quote }}
     enable-refresh-tokens: true
     server-write-timeout: {{ .app.harness.proxy.timeout.send | default .root.Values.proxy.timeout.send | default 180 }}s
     upstream-timeout: {{ .app.harness.proxy.timeout.read | default .root.Values.proxy.timeout.read | default 180 }}s
@@ -38,7 +40,6 @@ data:
     tls-cert:
     tls-private-key:
     redirection-url: {{ ternary "https" "http" $tls }}://{{ .subdomain }}.{{ .root.Values.domain }}
-    encryption-key: AgXa7xRcoClDEU0ZDSH4X0XhL5Qy2Z2j
     upstream-url: http://{{ .app.harness.service.name }}.{{ .app.namespace | default .root.Release.Namespace }}:{{ .app.harness.service.port | default 80}}
     {{ if .app.harness.secured }}
       {{ with .app.harness.uri_role_mapping }}
@@ -135,7 +136,7 @@ spec:
 {{ include "deploy_utils.etcHosts" .root | indent 6 }}
       containers:
       - name: {{ .app.harness.service.name | quote }}
-        image: {{ .app.harness.proxy.gatekeeper.image | default .root.Values.proxy.gatekeeper.image | default "quay.io/gogatekeeper/gatekeeper:2.14.3" }}
+        image: {{ .app.harness.proxy.gatekeeper.image | default .root.Values.proxy.gatekeeper.image | default "quay.io/gogatekeeper/gatekeeper:4.6.0" }}
         imagePullPolicy: IfNotPresent
         {{ if .root.Values.local }}
         securityContext:

--- a/deployment-configuration/value-template.yaml
+++ b/deployment-configuration/value-template.yaml
@@ -55,7 +55,8 @@ harness:
     # -- Service port.
     port: 80
   # -- Auto generated secrets key-value pairs. If no value is provided, a random hash is generated
-  secrets: {}
+  secrets:
+    gatekeeper:
   # -- Specify which services this application uses in the frontend to create proxy ingresses. e.g. - name: mnp-checkout
   use_services: []
   # -- enabled sentry for automated error report


### PR DESCRIPTION
Closes [CH-224](https://metacell.atlassian.net/browse/CH-224)

# Implemented solution

Sets enable-encrypted-token: false
Introduces configurable gk encryption key secret.
Updates to gk 4.6.0

# How to test this PR

...

# Sanity checks:
- [ ] The pull request is explicitly linked to the relevant issue(s)
- [ ] The issue is well described: clearly states the problem and the general proposed solution(s)
- [ ] In this PR it is explicitly stated how to test the current change
- [ ] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] The relevant components are indicated in the issue (if any)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one Sprint
- [ ] All the linked issues are in the Review state
- [ ] All the linked issues are assigned

# Breaking changes (select one):
- [ ] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change` and the migration procedure is well described [above](#implemented-solution)

# Possible deployment updates issues (select one):
- [ ] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif


[CH-224]: https://metacell.atlassian.net/browse/CH-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ