### PR TITLE
liveness probe to check message processing

### DIFF
--- a/applications/events/deploy/templates/deployments.yml
+++ b/applications/events/deploy/templates/deployments.yml
@@ -66,7 +66,7 @@ spec:
             command:
             - /bin/sh
             - -c
-            - /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 --timeout 10000
+            - timeout 10 /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092
           initialDelaySeconds: 60
           periodSeconds: 30
           timeoutSeconds: 15

--- a/applications/events/deploy/templates/deployments.yml
+++ b/applications/events/deploy/templates/deployments.yml
@@ -62,11 +62,15 @@ spec:
           periodSeconds: 15
           timeoutSeconds: 5
         livenessProbe:
-          tcpSocket:
-            port: client
-          initialDelaySeconds: 30
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 --timeout 10000
+          initialDelaySeconds: 60
           periodSeconds: 30
-          timeoutSeconds: 5
+          timeoutSeconds: 15
+          failureThreshold: 3
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
# Implemented solution

Replacing TCP socket probe with liveness probe to check that the broker is still alive:
- Opens a connection to localhost:9092
- Sends a ApiVersions request (a standard Kafka protocol request)
- The broker responds with the list of API versions it supports
- The script prints them and exits 0 
If the broker freeze (happened in the past during cluster upgrades) this should trigger a liveness failure and K8s will take care of the rest.

# How to test this PR

Freeze the Kafka JVM without killing the TCP port.
```
# Freeze the process (port stays open, broker stops responding)
kubectl exec -n ifn kafka-0 -- kill -STOP 1
```
Then watch K8s:
```
kubectl get pod -n ifn kafka-0 -w
```
After ~90 s (3 × 30 s periods) you should see the RESTARTS counter increment.

# Sanity checks:
- [ ] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] In this PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] The relevant components are indicated in the issue (if any)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one Sprint
- [ ] All the linked issues are in the Review state
- [ ] All the linked issues are assigned

# Breaking changes (select one):
- [ ] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change` and the migration procedure is well described [above](#implemented-solution)

# Possible deployment updates issues (select one):
- [ ] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
