### PR TITLE
fix: improve logging for user sync errors in _get_user function

### DIFF
--- a/infrastructure/common-images/cloudharness-django/libraries/cloudharness-django/cloudharness_django/middleware.py
+++ b/infrastructure/common-images/cloudharness-django/libraries/cloudharness-django/cloudharness_django/middleware.py
@@ -102,7 +102,7 @@ def _get_user(kc_user_id: str) -> User:
             return user
 
         except Exception as e:
-            log.exception("User sync error, %s", kc_user.email)
+            log.exception("User sync error for kc_id %s", kc_user_id)
             return None
 
         return user

--- a/libraries/cloudharness-common/cloudharness/auth/keycloak.py
+++ b/libraries/cloudharness-common/cloudharness/auth/keycloak.py
@@ -118,7 +118,7 @@ def _get_public_key_cache_path():
         from django.conf import settings
         return os.path.join(settings.PERSISTENT_ROOT, "cloudharness_public_key")
     except ImportError:
-        return "/tmp/cloudharness_public_key" 
+        return "/tmp/cloudharness_public_key"
     except Exception:
         log.exception("Could not get Django settings, using /tmp for public key cache")
         return "/tmp/cloudharness_public_key"


### PR DESCRIPTION
Closes - https://metacell.atlassian.net/browse/NGLASS-1881

# Implemented solution
In _get_user() inside cloudharness_django/middleware.py, the outer except Exception handler referenced kc_user.email in the log call. kc_user is only assigned inside inner try blocks, so if an unexpected exception (e.g. a transient DB error) fires before any of those assignments run, Python raises a secondary UnboundLocalError: cannot access local variable 'kc_user', which itself propagates to Sentry.

Replaced kc_user.email with kc_user_id (always in scope at that point) in the log call and removed the stale commented-out line.

# How to test this PR
In a test environment, mock User.objects.get to raise a generic Exception (not DoesNotExist/MultipleObjectsReturned) when called inside _get_user
Make an authenticated request (e.g. GET /api/figures/) with a valid Bearer token
Confirm the request returns an anonymous/unauthenticated response (no 500)
Confirm the log output contains "User sync error for kc_id <id>" — not an UnboundLocalError
Confirm no new UnboundLocalError events appear in Sentry

# Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] In this PR it is explicitly stated how to test the current change
- [ ] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] The relevant components are indicated in the issue (if any)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one Sprint
- [ ] All the linked issues are in the Review state
- [ ] All the linked issues are assigned

# Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change` and the migration procedure is well described [above](#implemented-solution)

# Possible deployment updates issues (select one):
- [ ] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
