### PR TITLE
feat: Add postgres operator parameters

### DIFF
--- a/deployment-configuration/helm/templates/auto-database-postgres-operator.yaml
+++ b/deployment-configuration/helm/templates/auto-database-postgres-operator.yaml
@@ -27,7 +27,9 @@ spec:
   {{- with .app.harness.database.postgres.parameters }}
   postgresql:
     parameters:
-{{ toYaml . | nindent 6 }}
+{{- range $key, $value := . }}
+      {{ $key }}: {{ $value | quote }}
+{{- end }}
   {{- end }}
 
   inheritedMetadata:

--- a/deployment-configuration/helm/templates/auto-database-postgres-operator.yaml
+++ b/deployment-configuration/helm/templates/auto-database-postgres-operator.yaml
@@ -24,6 +24,12 @@ metadata:
 spec:
   instances: {{ .app.harness.database.postgres.instances | default 1 }}
 
+  {{- with .app.harness.database.postgres.parameters }}
+  postgresql:
+    parameters:
+{{ toYaml . | nindent 6 }}
+  {{- end }}
+
   inheritedMetadata:
     labels:
       app: {{ .app.harness.database.name | quote }}

--- a/deployment-configuration/value-template.yaml
+++ b/deployment-configuration/value-template.yaml
@@ -115,6 +115,8 @@ harness:
       # -- CIDR(s) allowed for CNPG pods to reach the Kubernetes API server (port 443).
       # -- Resolved automatically at deploy time via cluster lookup. Set explicitly only as a fallback for helm-template or air-gapped use.
       apiServerCidr: []
+      # -- PostgreSQL configuration parameters for CloudNative-PG clusters (operator: true). Values must be strings.
+      parameters: {}
       ports:
         - name: http
           port: 5432

--- a/docs/applications/databases.md
+++ b/docs/applications/databases.md
@@ -87,6 +87,7 @@ harness
       operator: false
       instances: 1
       apiServerCidr: []
+      parameters: {}
       ports:
         - name: http
           port: 5432
@@ -108,6 +109,8 @@ helm install cnpg cloudnative-pg/cloudnative-pg
 `instances`: Number of PostgreSQL instances (replicas) managed by the CNPG operator. Only used when `operator: true`. Default is 1.
 
 `apiServerCidr`: List of CIDRs allowed for CNPG database pods to reach the Kubernetes API server on port 443. **Resolved automatically at deploy time** by looking up the `kubernetes` Service and Endpoints in the `default` namespace. The explicit list is only used as a fallback when lookup returns nothing (e.g. `helm template` dry-run). Leave empty (`[]`) for auto-detection; set explicitly only for air-gapped or restricted environments.
+
+`parameters`: Optional map of PostgreSQL configuration parameters rendered to CloudNative-PG as `spec.postgresql.parameters` when `operator: true`. Values must be strings, for example `max_connections: "200"`. CloudNative-PG rejects parameters that are fixed or managed by the operator.
 
 
 #### Neo4j
@@ -207,6 +210,5 @@ Further reading: [MongoDB archiving & compression](https://www.mongodb.com/blog/
 `pg_dumpall` is used to create for each database a gzipped script.
 
 Further reading: [pg_dumpall docs](https://www.postgresql.org/docs/10/app-pg-dumpall.html)
-
 
 

--- a/docs/model/DatabaseConfig.md
+++ b/docs/model/DatabaseConfig.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **operator** | **bool** | Use the CloudNative-PG operator instead of a plain Deployment (postgres only) | [optional] 
 **instances** | **int** | Number of PostgreSQL instances managed by the CNPG operator (only used when operator is true) | [optional] 
 **api_server_cidr** | **List[str]** | CIDR(s) allowed for CNPG pods to reach the Kubernetes API server (port 443). Override with your cluster API-server or service CIDR. | [optional] 
+**parameters** | **Dict[str, str]** | PostgreSQL configuration parameters passed to CloudNative-PG as spec.postgresql.parameters (postgres operator only). Values must be strings. | [optional] 
 **initialdb** | **str** | Initial database name (postgres only) | [optional] 
 **args** | **List[str]** | Additional command-line arguments passed to the database server process (postgres only) | [optional] 
 

--- a/libraries/models/api/openapi.yaml
+++ b/libraries/models/api/openapi.yaml
@@ -962,6 +962,11 @@ components:
                     type: array
                     items:
                         type: string
+                parameters:
+                    description: 'PostgreSQL configuration parameters passed to CloudNative-PG as spec.postgresql.parameters (postgres operator only). Values must be strings.'
+                    type: object
+                    additionalProperties:
+                        type: string
                 initialdb:
                     description: 'Initial database name (postgres only)'
                     type: string

--- a/libraries/models/cloudharness_model/models/database_config.py
+++ b/libraries/models/cloudharness_model/models/database_config.py
@@ -37,10 +37,11 @@ class DatabaseConfig(CloudHarnessBaseModel):
     operator: Optional[StrictBool] = Field(default=None, description="Use the CloudNative-PG operator instead of a plain Deployment (postgres only)")
     instances: Optional[Annotated[int, Field(strict=True, ge=1)]] = Field(default=None, description="Number of PostgreSQL instances managed by the CNPG operator (only used when operator is true)")
     api_server_cidr: Optional[List[StrictStr]] = Field(default=None, description="CIDR(s) allowed for CNPG pods to reach the Kubernetes API server (port 443). Override with your cluster API-server or service CIDR.", alias="apiServerCidr")
+    parameters: Optional[Dict[str, StrictStr]] = Field(default=None, description="PostgreSQL configuration parameters passed to CloudNative-PG as spec.postgresql.parameters (postgres operator only). Values must be strings.")
     initialdb: Optional[StrictStr] = Field(default=None, description="Initial database name (postgres only)")
     args: Optional[List[StrictStr]] = Field(default=None, description="Additional command-line arguments passed to the database server process (postgres only)")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["image", "name", "ports", "operator", "instances", "apiServerCidr", "initialdb", "args"]
+    __properties: ClassVar[List[str]] = ["image", "name", "ports", "operator", "instances", "apiServerCidr", "parameters", "initialdb", "args"]
 
     def to_dict(self) -> Dict[str, Any]:
         """Return the dictionary representation of the model using alias.
@@ -92,6 +93,7 @@ class DatabaseConfig(CloudHarnessBaseModel):
             "operator": obj.get("operator"),
             "instances": obj.get("instances"),
             "apiServerCidr": obj.get("apiServerCidr"),
+            "parameters": obj.get("parameters"),
             "initialdb": obj.get("initialdb"),
             "args": obj.get("args")
         })

--- a/libraries/models/docs/DatabaseConfig.md
+++ b/libraries/models/docs/DatabaseConfig.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **operator** | **bool** | Use the CloudNative-PG operator instead of a plain Deployment (postgres only) | [optional] 
 **instances** | **int** | Number of PostgreSQL instances managed by the CNPG operator (only used when operator is true) | [optional] 
 **api_server_cidr** | **List[str]** | CIDR(s) allowed for CNPG pods to reach the Kubernetes API server (port 443). Override with your cluster API-server or service CIDR. | [optional] 
+**parameters** | **Dict[str, str]** | PostgreSQL configuration parameters passed to CloudNative-PG as spec.postgresql.parameters (postgres operator only). Values must be strings. | [optional] 
 **initialdb** | **str** | Initial database name (postgres only) | [optional] 
 **args** | **List[str]** | Additional command-line arguments passed to the database server process (postgres only) | [optional] 
 

--- a/libraries/models/test/test_deserialize.py
+++ b/libraries/models/test/test_deserialize.py
@@ -2,7 +2,7 @@ import pytest
 from os.path import join, dirname as dn, realpath
 import oyaml as yaml
 
-from cloudharness_model import HarnessMainConfig, ApplicationConfig, User, ApplicationHarnessConfig, CDCEvent, ApplicationTestConfig
+from cloudharness_model import HarnessMainConfig, ApplicationConfig, User, ApplicationHarnessConfig, CDCEvent, ApplicationTestConfig, DatabaseConfig
 
 HERE = dn(realpath(__file__))
 
@@ -36,6 +36,27 @@ def test_camelcase():
     u = User().from_dict(dict(lastName="a"))
     assert u.last_name == "a"
     assert u["lastName"] == "a"
+
+
+def test_database_config_parameters_round_trip():
+    config = DatabaseConfig.from_dict({
+        "image": "postgres:17",
+        "operator": True,
+        "parameters": {
+            "max_connections": "200",
+            "shared_buffers": "1GB",
+        },
+    })
+
+    assert config.parameters == {
+        "max_connections": "200",
+        "shared_buffers": "1GB",
+    }
+    assert config.to_dict()["parameters"] == {
+        "max_connections": "200",
+        "shared_buffers": "1GB",
+    }
+
 
 def test_robustness():
     d = {'aliases': [], 'database': {'auto': True, 'mongo': {'image': 'mongo:5', 'ports': [{'name': 'http', 'port': 27017}]}, 'name': 'keycloak-postgres', 'neo4j': {'dbms_security_auth_enabled': 'false', 'image': 'neo4j:4.1.9', 'memory': {'heap': {'initial': '64M', 'max': '128M'}, 'pagecache': {'size': '64M'}, 'size': '256M'}, 'ports': [{'name': 'http', 'port': 7474}, {'name': 'bolt', 'port': 7687}]}, 'pass': 'password', 'postgres': {'image': 'postgres:10.4', 'initialdb': 'auth_db', 'ports': [{'name': 'http', 'port': 5432}]}, 'resources': {'limits': {'cpu': '1000m', 'memory': '2Gi'}, 'requests': {'cpu': '100m', 'memory': '512Mi'}}, 'size': '2Gi', 'type': 'postgres', 'user': 'user'}, 'dependencies': {'build': [], 'hard': [], 'soft': []}, 'deployment': {'auto': True, 'image': 'osb/accounts:3e02a15477b4696ed554e08cedf4109c67908cbe6b03331072b5b73e83b4fc2b', 'name': 'accounts', 'port': 8080, 'replicas': 1, 'resources': {'limits': {'cpu': '500m', 'memory': '1024Mi'}, 'requests': {'cpu': '10m', 'memory': '512Mi'}}}, 'domain': None, 'env': [{'name': 'KEYCLOAK_IMPORT', 'value': '/tmp/realm.json'},

--- a/tools/deployment-cli-tools/tests/test_helm.py
+++ b/tools/deployment-cli-tools/tests/test_helm.py
@@ -2,6 +2,8 @@ from ch_cli_tools.helm import *
 from ch_cli_tools.configurationgenerator import *
 from ch_cli_tools.preprocessing import preprocess_build_overrides, generate_hash_based_image_tags
 import pytest
+import shutil
+import subprocess
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 RESOURCES = os.path.join(HERE, 'resources')
@@ -10,6 +12,24 @@ CLOUDHARNESS_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(HERE)))
 
 def exists(path):
     return path.exists()
+
+
+def render_helm_chart(chart_path):
+    completed = subprocess.run(
+        ["helm", "template", str(chart_path)],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return [manifest for manifest in yaml.safe_load_all(completed.stdout) if manifest]
+
+
+def find_manifest(manifests, kind, name):
+    for manifest in manifests:
+        if manifest.get("kind") == kind and manifest.get("metadata", {}).get("name") == name:
+            return manifest
+    raise AssertionError(f"Could not find {kind}/{name}")
 
 
 def test_collect_helm_values(tmp_path):
@@ -292,6 +312,50 @@ def test_clear_unused_dbconfig(tmp_path):
     assert db_config['neo4j'] is None
 
     assert db_config['postgres'] is None
+
+
+def test_cnpg_postgres_parameters_render_only_when_set(tmp_path):
+    out_folder = tmp_path / 'test_cnpg_postgres_parameters_render_only_when_set'
+    create_helm_chart([CLOUDHARNESS_ROOT, RESOURCES], output_path=out_folder, domain="my.local",
+                      env='withpostgres', local=False, include=["myapp"], exclude=["legacy"])
+
+    helm_path = out_folder / HELM_CHART_PATH
+    shutil.rmtree(helm_path / 'charts')
+    values_path = helm_path / 'values.yaml'
+    with open(values_path, 'r') as values_file:
+        values = yaml.safe_load(values_file)
+    postgres = values['apps']['myapp']['harness']['database']['postgres']
+    postgres['operator'] = True
+    postgres['parameters'] = {
+        'max_connections': '200',
+        'shared_buffers': '1GB',
+    }
+    with open(values_path, 'w') as values_file:
+        yaml.safe_dump(values, values_file)
+
+    manifests = render_helm_chart(helm_path)
+    db_name = values['apps']['myapp']['harness']['database']['name']
+    cluster = find_manifest(manifests, 'Cluster', db_name)
+    assert cluster['spec']['postgresql']['parameters'] == {
+        'max_connections': '200',
+        'shared_buffers': '1GB',
+    }
+
+    postgres['parameters'] = {}
+    with open(values_path, 'w') as values_file:
+        yaml.safe_dump(values, values_file)
+
+    manifests = render_helm_chart(helm_path)
+    cluster = find_manifest(manifests, 'Cluster', db_name)
+    assert 'postgresql' not in cluster['spec']
+
+    postgres.pop('parameters')
+    with open(values_path, 'w') as values_file:
+        yaml.safe_dump(values, values_file)
+
+    manifests = render_helm_chart(helm_path)
+    cluster = find_manifest(manifests, 'Cluster', db_name)
+    assert 'postgresql' not in cluster['spec']
 
 
 def test_clear_all_dbconfig_if_nodb(tmp_path):

--- a/tools/deployment-cli-tools/tests/test_helm.py
+++ b/tools/deployment-cli-tools/tests/test_helm.py
@@ -327,8 +327,12 @@ def test_cnpg_postgres_parameters_render_only_when_set(tmp_path):
     postgres = values['apps']['myapp']['harness']['database']['postgres']
     postgres['operator'] = True
     postgres['parameters'] = {
+        # Simulate generated YAML values where on/off can be parsed as booleans before Helm renders the chart.
+        'autovacuum': True,
         'max_connections': '200',
         'shared_buffers': '1GB',
+        'synchronous_commit': True,
+        'track_io_timing': False,
     }
     with open(values_path, 'w') as values_file:
         yaml.safe_dump(values, values_file)
@@ -337,8 +341,11 @@ def test_cnpg_postgres_parameters_render_only_when_set(tmp_path):
     db_name = values['apps']['myapp']['harness']['database']['name']
     cluster = find_manifest(manifests, 'Cluster', db_name)
     assert cluster['spec']['postgresql']['parameters'] == {
+        'autovacuum': 'true',
         'max_connections': '200',
         'shared_buffers': '1GB',
+        'synchronous_commit': 'true',
+        'track_io_timing': 'false',
     }
 
     postgres['parameters'] = {}


### PR DESCRIPTION
Adds support for `harness.database.postgres.parameters` when using the CloudNativePG operator, rendering non-empty values into Cluster.spec.postgresql.parameters.

Changes
- Added postgres.parameters as an optional map[string]string config field.
- Updated CNPG Helm rendering to include spec.postgresql.parameters only when set.
- Updated generated model/docs and database configuration docs.
- Added regression coverage for Helm rendering and model serialization.

Conceptually similar to https://github.com/MetaCell/cloud-harness/commit/3b20f748acaeeba70be009b9cdd49cabf61e0ec7