### PR TITLE
CH-291 Harmonize yaml libraries and formatting

### DIFF
--- a/libraries/models/test-requirements.txt
+++ b/libraries/models/test-requirements.txt
@@ -3,4 +3,4 @@ pytest-cov>=2.8.1
 pytest-randomly>=3.12.0
 mypy>=1.4.1
 types-python-dateutil>=2.8.19
-oyaml
+ruamel.yaml

--- a/libraries/models/test/test_backwards_compatibility.py
+++ b/libraries/models/test/test_backwards_compatibility.py
@@ -1,7 +1,7 @@
 
 from cloudharness_model import HarnessMainConfig, ApplicationConfig, User, ApplicationHarnessConfig, CDCEvent
 from os.path import join, dirname as dn, realpath
-import oyaml as yaml
+from ruamel.yaml import YAML
 
 HERE = dn(realpath(__file__))
 
@@ -37,7 +37,7 @@ def test_dict_behaviour():
 
 def test_usages():
     with open(join(HERE, "resources/values.yaml")) as f:
-        values = yaml.safe_load(f)
+        values = YAML(typ="safe").load(f)
         v = HarnessMainConfig.from_dict(values)
     assert v.apps["accounts"].harness.database
     assert v.apps["accounts"].client.id

--- a/libraries/models/test/test_deserialize.py
+++ b/libraries/models/test/test_deserialize.py
@@ -1,5 +1,5 @@
 from os.path import join, dirname as dn, realpath
-import oyaml as yaml
+from ruamel.yaml import YAML
 
 from cloudharness_model import HarnessMainConfig, ApplicationConfig, User, ApplicationHarnessConfig, CDCEvent, ApplicationTestConfig, DatabaseConfig, GatekeeperConf
 
@@ -8,7 +8,7 @@ HERE = dn(realpath(__file__))
 
 def test_helm_values_deserialize():
     with open(join(HERE, "resources/values.yaml")) as f:
-        values = yaml.safe_load(f)
+        values = YAML(typ="safe").load(f)
     v = HarnessMainConfig.from_dict(values)
 
     assert v.domain

--- a/libraries/models/test/test_serialize.py
+++ b/libraries/models/test/test_serialize.py
@@ -2,7 +2,7 @@
 import json
 from os.path import join, dirname as dn, realpath
 
-import oyaml as yaml
+from ruamel.yaml import YAML
 
 from cloudharness_model import HarnessMainConfig, ApplicationConfig, User, ApplicationHarnessConfig
 from cloudharness_model.encoder import CloudHarnessJSONEncoder
@@ -11,7 +11,7 @@ HERE = dn(realpath(__file__))
 
 def test_json_serialize():
     with open(join(HERE, "resources/values.yaml")) as f:
-        values = yaml.safe_load(f)
+        values = YAML(typ="safe").load(f)
     v = HarnessMainConfig.from_dict(values)
     dumped = json.dumps(v, cls=CloudHarnessJSONEncoder)
     cloned = json.loads(dumped)

--- a/tools/deployment-cli-tools/ch_cli_tools/codefresh.py
+++ b/tools/deployment-cli-tools/ch_cli_tools/codefresh.py
@@ -6,7 +6,7 @@ from cloudharness_model.models.git_dependency_config import GitDependencyConfig
 import logging
 from cloudharness_model.models.api_tests_config import ApiTestsConfig
 
-import oyaml as yaml
+from ruamel.yaml.scalarstring import SingleQuotedScalarString
 
 from cloudharness_utils.testing.util import get_app_environment
 from .models import HarnessMainConfig, ApplicationTestConfig, ApplicationHarnessConfig
@@ -14,7 +14,7 @@ from cloudharness_utils.constants import *
 from .configurationgenerator import KEY_APPS, KEY_TASK_IMAGES, KEY_TEST_IMAGES
 from .secrets import is_cloudharness_managed, is_secret_config, secret_value
 from .utils import check_image_exists_in_registry, find_dockerfiles_paths, get_app_relative_to_base_path, guess_build_dependencies_from_dockerfile, \
-    get_template, dict_merge, app_name_from_path, clean_path, strip_registry_tag, get_image_source
+    get_template, dict_merge, app_name_from_path, clean_path, strip_registry_tag, get_image_source, yaml, yaml_rt
 from cloudharness_utils.testing.api import get_api_filename, get_schemathesis_command, get_urls_from_api_file
 
 logging.getLogger().setLevel(logging.INFO)
@@ -43,19 +43,6 @@ def _to_codefresh_path(path: str) -> str:
     if i > 0 and i < len(parts) and parts[i] == CLOUD_HARNESS_PATH:
         return '/'.join([CLOUD_HARNESS_PATH] + parts[i + 1:])
     return rel
-
-# Codefresh variables may need quotes: adjust yaml dump accordingly
-
-
-def literal_presenter(dumper, data):
-    if isinstance(data, str) and "\n" in data:
-        return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
-    if isinstance(data, str) and data.startswith('${{'):
-        return dumper.represent_scalar('tag:yaml.org,2002:str', data, style="'")
-    return dumper.represent_scalar('tag:yaml.org,2002:str', data)
-
-
-yaml.add_representer(str, literal_presenter)
 
 
 def clean_step_key(s: str) -> str:
@@ -236,7 +223,7 @@ def create_codefresh_deployment_scripts(root_paths, envs=(), include=(), exclude
                 logging.info("Specific build template found: %s" %
                              (specific_build_template_path))
                 with open(specific_build_template_path) as f:
-                    build_specific = yaml.safe_load(f)
+                    build_specific = yaml.load(f)
 
                 build_specific.pop(
                     'build_arguments') if 'build_arguments' in build_specific else []
@@ -551,8 +538,6 @@ def create_codefresh_deployment_scripts(root_paths, envs=(), include=(), exclude
         codefresh_dir = dirname(codefresh_abs_path)
         if not exists(codefresh_dir):
             os.makedirs(codefresh_dir)
-        from ruamel.yaml.scalarstring import SingleQuotedScalarString
-
         deployment_step = codefresh.get("steps", {}).get("deployment", {})
         arguments = deployment_step.get("arguments", {})
         if "custom_values" in arguments:
@@ -561,11 +546,10 @@ def create_codefresh_deployment_scripts(root_paths, envs=(), include=(), exclude
                 for v in arguments["custom_values"]
             ]
 
-        from ruamel.yaml import YAML
-        ryaml = YAML()
-        ryaml.default_flow_style = False
+        # Round trip handler: the codefresh steps are deliberately ordered by stage,
+        # a sorting representer would scramble them.
         with open(codefresh_abs_path, 'w') as f:
-            ryaml.dump(codefresh, f)
+            yaml_rt.dump(codefresh, f)
     return codefresh
 
 

--- a/tools/deployment-cli-tools/ch_cli_tools/configurationgenerator.py
+++ b/tools/deployment-cli-tools/ch_cli_tools/configurationgenerator.py
@@ -3,7 +3,6 @@ Utilities to create a helm chart from a CloudHarness directory structure
 """
 from typing import List, Union
 import copy
-import yaml
 import os
 import shutil
 import logging
@@ -18,7 +17,7 @@ from cloudharness_utils.constants import TEST_IMAGES_PATH, HELM_CHART_PATH, APPS
     DEPLOYMENT_CONFIGURATION_PATH, BASE_IMAGES_PATH, STATIC_IMAGES_PATH
 from .utils import get_cluster_ip, env_variable, get_dockerfile_baseimg_args, get_sub_paths, guess_build_dependencies_from_dockerfile, image_name_from_dockerfile_path, \
     get_template, merge_configuration_directories, dict_merge, app_name_from_path, \
-    find_dockerfiles_paths, get_git_commit_hash
+    find_dockerfiles_paths, get_git_commit_hash, yaml
 from .secrets import secret_definition_error
 
 
@@ -111,7 +110,7 @@ class ConfigurationGenerator(object, metaclass=abc.ABCMeta):
     def _adjust_missing_values(self, helm_values):
         if 'name' not in helm_values:
             with open(self.helm_chart_path) as f:
-                chart_idx_content = yaml.safe_load(f)
+                chart_idx_content = yaml.load(f)
             helm_values['name'] = chart_idx_content['name'].lower()
 
     def _process_applications(self, helm_values, base_image_name=None):
@@ -481,7 +480,7 @@ def collect_helm_values(deployment_root, env=()):
             logging.info(
                 "Specific environment values template found: " + specific_template_path)
             with open(specific_template_path) as f:
-                values_env_specific = yaml.safe_load(f)
+                values_env_specific = yaml.load(f)
             values = dict_merge(values, values_env_specific)
     return values
 

--- a/tools/deployment-cli-tools/ch_cli_tools/dockercompose.py
+++ b/tools/deployment-cli-tools/ch_cli_tools/dockercompose.py
@@ -3,8 +3,6 @@ Utilities to create a helm chart from a CloudHarness directory structure
 """
 from pathlib import Path
 from typing import Union
-import yaml
-from ruamel.yaml import YAML
 import os
 import logging
 import subprocess
@@ -13,7 +11,8 @@ import copy
 
 from cloudharness_utils.constants import VALUES_MANUAL_PATH, COMPOSE
 from .utils import get_cluster_ip, image_name_from_dockerfile_path, get_template, \
-    merge_to_yaml_file, dict_merge, app_name_from_path, find_dockerfiles_paths, find_file_paths
+    merge_to_yaml_file, dict_merge, app_name_from_path, find_dockerfiles_paths, find_file_paths, \
+    yaml, yaml_rt
 
 from .models import HarnessMainConfig
 
@@ -142,8 +141,7 @@ class CloudHarnessDockerCompose(ConfigurationGenerator):
             logging.warning("Something went wrong during the docker-compose.yaml generation, cannot post-process it")
             return
 
-        yaml_handler = YAML()
-        documents = yaml_handler.load_all(yaml_document)
+        documents = yaml_rt.load_all(yaml_document)
 
         main_document = None
         for document in documents:
@@ -161,7 +159,7 @@ class CloudHarnessDockerCompose(ConfigurationGenerator):
                 # so if we modify it while looping on "documents"
                 # the output will be affected (probably truncated for some outputs)
                 main_document = document  # we need to save the main document later
-        yaml_handler.dump(main_document, yaml_document)
+        yaml_rt.dump(main_document, yaml_document)
 
     def __get_default_helm_values_with_secrets(self, helm_values):
         helm_values = copy.deepcopy(helm_values)
@@ -276,7 +274,7 @@ class CloudHarnessDockerCompose(ConfigurationGenerator):
                 logging.info(
                     f"Specific environment values template found: {specific_template_path}")
                 with open(specific_template_path) as f:
-                    values_env_specific = yaml.safe_load(f)
+                    values_env_specific = yaml.load(f)
                 values = dict_merge(values, values_env_specific)
 
         if KEY_HARNESS in values and 'name' in values[KEY_HARNESS] and values[KEY_HARNESS]['name']:
@@ -362,7 +360,7 @@ class CloudHarnessDockerCompose(ConfigurationGenerator):
                 logging.info(
                     f"Specific environment values template found: {specific_template_path}")
                 with open(specific_template_path) as f:
-                    values_env_specific = yaml.safe_load(f)
+                    values_env_specific = yaml.load(f)
                 values = dict_merge(values, values_env_specific)
 
         if KEY_HARNESS in values and 'name' in values[KEY_HARNESS] and values[KEY_HARNESS]['name']:

--- a/tools/deployment-cli-tools/ch_cli_tools/helm.py
+++ b/tools/deployment-cli-tools/ch_cli_tools/helm.py
@@ -3,7 +3,6 @@ Utilities to create a helm chart from a CloudHarness directory structure
 """
 from pathlib import Path
 from typing import Union
-import yaml
 import os
 import logging
 from hashlib import sha1
@@ -12,7 +11,7 @@ import subprocess
 from cloudharness_utils.constants import VALUES_MANUAL_PATH, HELM_CHART_PATH
 from .utils import get_cluster_ip, get_dockerfile_baseimg_args, get_git_commit_hash, get_image_name, image_name_from_dockerfile_path, \
     get_template, merge_to_yaml_file, dict_merge, app_name_from_path, \
-    find_dockerfiles_paths
+    find_dockerfiles_paths, yaml
 
 from .models import HarnessMainConfig
 
@@ -352,7 +351,7 @@ class CloudHarnessHelm(ConfigurationGenerator):
             if specific_template_path.exists():
                 logging.info(f"Specific environment values template found: {specific_template_path}")
                 with specific_template_path.open("r") as f:
-                    values_env_specific = yaml.safe_load(f)
+                    values_env_specific = yaml.load(f)
                 values = dict_merge(values, values_env_specific)
 
         if KEY_HARNESS in values and 'name' in values[KEY_HARNESS] and values[KEY_HARNESS]['name']:
@@ -426,7 +425,7 @@ class CloudHarnessHelm(ConfigurationGenerator):
                 logging.info(
                     "Specific environment values template found: " + specific_template_path)
                 with open(specific_template_path) as f:
-                    values_env_specific = yaml.safe_load(f)
+                    values_env_specific = yaml.load(f)
                 values = dict_merge(values, values_env_specific)
 
         if KEY_HARNESS in values and 'name' in values[KEY_HARNESS] and values[KEY_HARNESS]['name']:

--- a/tools/deployment-cli-tools/ch_cli_tools/openapi.py
+++ b/tools/deployment-cli-tools/ch_cli_tools/openapi.py
@@ -17,7 +17,7 @@ from ch_cli_tools.common_types import TemplateType
 from ch_cli_tools.manifest import get_manifest
 
 from . import HERE
-from .utils import confirm, copymergedir, replace_in_file, replaceindir, to_python_module, get_apps_paths
+from .utils import confirm, copymergedir, replace_in_file, replaceindir, to_python_module, get_apps_paths, yaml
 
 CODEGEN = os.path.join(HERE, 'bin', 'openapi-generator-cli.jar')
 APPLICATIONS_SRC_PATH = os.path.join('applications')
@@ -147,7 +147,6 @@ def generate_ts_client(openapi_file, app_name=""):
 
 
 def json2yaml(json_filename, yaml_file=None):
-    import yaml
     if yaml_file is None:
         yaml_file = str(json_filename).replace('.json', '.yaml')
     with open(json_filename, 'r') as json_filename:

--- a/tools/deployment-cli-tools/ch_cli_tools/utils.py
+++ b/tools/deployment-cli-tools/ch_cli_tools/utils.py
@@ -23,7 +23,18 @@ from cloudharness_utils.constants import NEUTRAL_PATHS, DEPLOYMENT_CONFIGURATION
     APPS_PATH, EXCLUDE_PATHS
 from . import CH_ROOT
 
+# Single YAML handler for the whole toolchain: ruamel.yaml.
+# `yaml` loads/dumps plain Python types; block style is forced so that generated
+# files never come out as inline `{a: 1, b: 2}` flow mappings.
 yaml = YAML(typ='safe')
+yaml.default_flow_style = False
+
+# Round trip handler, for the cases where the key order of the source document
+# (or of the dumped dictionary) must be preserved: the safe representer above
+# sorts mapping keys alphabetically.
+yaml_rt = YAML()
+yaml_rt.default_flow_style = False
+
 BASE_TEMPLATES_PATH = CH_ROOT
 
 

--- a/tools/deployment-cli-tools/requirements.txt
+++ b/tools/deployment-cli-tools/requirements.txt
@@ -1,7 +1,6 @@
 docker
 six
 ruamel.yaml
-oyaml
 cloudharness_model
 cloudharness_utils
 dirhash

--- a/tools/deployment-cli-tools/setup.py
+++ b/tools/deployment-cli-tools/setup.py
@@ -22,7 +22,6 @@ VERSION = "3.0.0"
 
 REQUIREMENTS = [
     'ruamel.yaml',
-    'oyaml',
     'docker',
     'six',
     'cloudharness_model',

--- a/tools/deployment-cli-tools/tests/test_dockercompose.py
+++ b/tools/deployment-cli-tools/tests/test_dockercompose.py
@@ -4,7 +4,7 @@ from ch_cli_tools.preprocessing import preprocess_build_overrides, generate_hash
 import pytest
 import shutil
 import subprocess
-import yaml
+from ch_cli_tools.utils import yaml
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 RESOURCES = os.path.join(HERE, 'resources')
@@ -110,7 +110,7 @@ def test_compose_gatekeeper_native_configuration_rendering(tmp_path):
     compose_path = out_folder / COMPOSE_PATH
     values_path = compose_path / 'values.yaml'
     with open(values_path, 'r') as values_file:
-        values = yaml.safe_load(values_file)
+        values = yaml.load(values_file)
 
     values['apps']['samples']['harness']['proxy']['gatekeeper']['configuration'] = {
         'same-site-cookie': 'None',
@@ -126,7 +126,7 @@ def test_compose_gatekeeper_native_configuration_rendering(tmp_path):
 
     def render_proxy_config():
         with open(values_path, 'w') as values_file:
-            yaml.safe_dump(values, values_file)
+            yaml.dump(values, values_file)
         completed = subprocess.run(
             ['helm', 'template', str(compose_path)],
             check=True,
@@ -134,10 +134,10 @@ def test_compose_gatekeeper_native_configuration_rendering(tmp_path):
             stderr=subprocess.PIPE,
             text=True,
         )
-        for document in yaml.safe_load_all(completed.stdout):
+        for document in yaml.load_all(completed.stdout):
             metadata = (document or {}).get('cloudharness-metadata', {})
             if metadata.get('path') == 'resources/generated/samples-gk/proxy.yml':
-                return yaml.safe_load(document['data'])
+                return yaml.load(document['data'])
         raise AssertionError('Could not find the samples Gatekeeper proxy configuration')
 
     tls_config = render_proxy_config()

--- a/tools/deployment-cli-tools/tests/test_helm.py
+++ b/tools/deployment-cli-tools/tests/test_helm.py
@@ -33,7 +33,7 @@ def render_helm_chart(chart_path):
         stderr=subprocess.PIPE,
         text=True,
     )
-    return [manifest for manifest in yaml.safe_load_all(completed.stdout) if manifest]
+    return [manifest for manifest in yaml.load_all(completed.stdout) if manifest]
 
 
 def find_manifest(manifests, kind, name):
@@ -112,7 +112,7 @@ def test_collect_helm_values(tmp_path):
     # Not indicated as a build dependency
     assert 'cloudharness-base-debian' not in values[KEY_TASK_IMAGES]
 
-    chart_values = yaml.safe_load(open(helm_path / 'charts/myapp/values.yaml', 'r'))  # Check if the values.yaml is valid YAML
+    chart_values = yaml.load(open(helm_path / 'charts/myapp/values.yaml', 'r'))  # Check if the values.yaml is valid YAML
     assert chart_values is not None, "values.yaml should be valid YAML"
     assert chart_values["test"] == "dev"
 
@@ -404,7 +404,7 @@ def test_cnpg_postgres_parameters_render_only_when_set(tmp_path):
     shutil.rmtree(helm_path / 'charts')
     values_path = helm_path / 'values.yaml'
     with open(values_path, 'r') as values_file:
-        values = yaml.safe_load(values_file)
+        values = yaml.load(values_file)
     postgres = values['apps']['myapp']['harness']['database']['postgres']
     postgres['operator'] = True
     postgres['parameters'] = {
@@ -416,7 +416,7 @@ def test_cnpg_postgres_parameters_render_only_when_set(tmp_path):
         'track_io_timing': False,
     }
     with open(values_path, 'w') as values_file:
-        yaml.safe_dump(values, values_file)
+        yaml.dump(values, values_file)
 
     manifests = render_helm_chart(helm_path)
     db_name = values['apps']['myapp']['harness']['database']['name']
@@ -431,7 +431,7 @@ def test_cnpg_postgres_parameters_render_only_when_set(tmp_path):
 
     postgres['parameters'] = {}
     with open(values_path, 'w') as values_file:
-        yaml.safe_dump(values, values_file)
+        yaml.dump(values, values_file)
 
     manifests = render_helm_chart(helm_path)
     cluster = find_manifest(manifests, 'Cluster', db_name)
@@ -439,7 +439,7 @@ def test_cnpg_postgres_parameters_render_only_when_set(tmp_path):
 
     postgres.pop('parameters')
     with open(values_path, 'w') as values_file:
-        yaml.safe_dump(values, values_file)
+        yaml.dump(values, values_file)
 
     manifests = render_helm_chart(helm_path)
     cluster = find_manifest(manifests, 'Cluster', db_name)
@@ -456,7 +456,7 @@ def test_statefulset_option(tmp_path):
     shutil.rmtree(helm_path / 'charts')
     values_path = helm_path / 'values.yaml'
     with open(values_path, 'r') as values_file:
-        values = yaml.safe_load(values_file)
+        values = yaml.load(values_file)
 
     myapp = values['apps']['myapp']
     harness = myapp['harness']
@@ -469,7 +469,7 @@ def test_statefulset_option(tmp_path):
         'name': 'myapp-data', 'mountpath': '/data', 'size': '1Gi', 'auto': True,
     }
     with open(values_path, 'w') as values_file:
-        yaml.safe_dump(values, values_file)
+        yaml.dump(values, values_file)
 
     # Default: Deployments with the Recreate/affinity workaround and a standalone PVC
     manifests = render_helm_chart(helm_path)
@@ -489,7 +489,7 @@ def test_statefulset_option(tmp_path):
     harness['deployment']['statefulset'] = True
     harness['database']['statefulset'] = True
     with open(values_path, 'w') as values_file:
-        yaml.safe_dump(values, values_file)
+        yaml.dump(values, values_file)
 
     manifests = render_helm_chart(helm_path)
     sts = find_manifest(manifests, 'StatefulSet', dep_name)
@@ -524,7 +524,7 @@ def test_statefulset_option(tmp_path):
     # PVC by claimName and no volumeClaimTemplates are created.
     harness['deployment']['volume']['usenfs'] = True
     with open(values_path, 'w') as values_file:
-        yaml.safe_dump(values, values_file)
+        yaml.dump(values, values_file)
 
     manifests = render_helm_chart(helm_path)
     sts = find_manifest(manifests, 'StatefulSet', dep_name)
@@ -540,7 +540,7 @@ def test_statefulset_option(tmp_path):
     harness['deployment']['volume']['usenfs'] = False
     harness['deployment']['volume']['auto'] = False
     with open(values_path, 'w') as values_file:
-        yaml.safe_dump(values, values_file)
+        yaml.dump(values, values_file)
 
     manifests = render_helm_chart(helm_path)
     sts = find_manifest(manifests, 'StatefulSet', dep_name)
@@ -560,7 +560,7 @@ def test_volume_write_many(tmp_path):
     shutil.rmtree(helm_path / 'charts')
     values_path = helm_path / 'values.yaml'
     with open(values_path, 'r') as values_file:
-        values = yaml.safe_load(values_file)
+        values = yaml.load(values_file)
 
     harness = values['apps']['myapp']['harness']
     dep_name = harness['deployment']['name']
@@ -571,7 +571,7 @@ def test_volume_write_many(tmp_path):
 
     def render():
         with open(values_path, 'w') as values_file:
-            yaml.safe_dump(values, values_file)
+            yaml.dump(values, values_file)
         return render_helm_chart(helm_path)
 
     # a null storage class is omitted, so the cluster default one is used
@@ -687,7 +687,7 @@ def test_volume_usenfs_prevails(tmp_path):
     shutil.rmtree(helm_path / 'charts')
     values_path = helm_path / 'values.yaml'
     with open(values_path, 'r') as values_file:
-        values = yaml.safe_load(values_file)
+        values = yaml.load(values_file)
 
     harness = values['apps']['myapp']['harness']
     harness['deployment']['auto'] = True
@@ -697,7 +697,7 @@ def test_volume_usenfs_prevails(tmp_path):
         'usenfs': True, 'writeMany': False, 'storageClass': 'efs-sc',
     }
     with open(values_path, 'w') as values_file:
-        yaml.safe_dump(values, values_file)
+        yaml.dump(values, values_file)
 
     manifests = render_helm_chart(helm_path)
     pvc = find_manifest(manifests, 'PersistentVolumeClaim', 'myapp-data')
@@ -737,14 +737,14 @@ def test_database_storage_class(tmp_path):
     shutil.rmtree(helm_path / 'charts')
     values_path = helm_path / 'values.yaml'
     with open(values_path, 'r') as values_file:
-        values = yaml.safe_load(values_file)
+        values = yaml.load(values_file)
 
     database = values['apps']['myapp']['harness']['database']
     db_name = database['name']
 
     def render():
         with open(values_path, 'w') as values_file:
-            yaml.safe_dump(values, values_file)
+            yaml.dump(values, values_file)
         return render_helm_chart(helm_path)
 
     # not set by default: the claim carries no storage class, so the cluster default one is used.
@@ -788,7 +788,7 @@ def test_statefulset_leader_service(tmp_path):
     shutil.rmtree(helm_path / 'charts')
     values_path = helm_path / 'values.yaml'
     with open(values_path, 'r') as values_file:
-        values = yaml.safe_load(values_file)
+        values = yaml.load(values_file)
 
     harness = values['apps']['myapp']['harness']
     dep_name = harness['deployment']['name']
@@ -807,7 +807,7 @@ def test_statefulset_leader_service(tmp_path):
         {'uri': '/readonly', 'methods': ['GET']},
     ]
     with open(values_path, 'w') as values_file:
-        yaml.safe_dump(values, values_file)
+        yaml.dump(values, values_file)
 
     manifests = render_helm_chart(helm_path)
     assert not any(m for m in manifests
@@ -817,7 +817,7 @@ def test_statefulset_leader_service(tmp_path):
 
     harness['deployment']['statefulset'] = True
     with open(values_path, 'w') as values_file:
-        yaml.safe_dump(values, values_file)
+        yaml.dump(values, values_file)
 
     manifests = render_helm_chart(helm_path)
     rw_service = find_manifest(manifests, 'Service', rw_name)
@@ -848,7 +848,7 @@ def test_gatekeeper_native_configuration_rendering_and_checksum(tmp_path):
     shutil.rmtree(helm_path / 'charts')
     values_path = helm_path / 'values.yaml'
     with open(values_path, 'r') as values_file:
-        values = yaml.safe_load(values_file)
+        values = yaml.load(values_file)
 
     app_harness = values['apps']['myapp']['harness']
     app_harness['secured'] = True
@@ -866,12 +866,12 @@ def test_gatekeeper_native_configuration_rendering_and_checksum(tmp_path):
 
     def render_gatekeeper():
         with open(values_path, 'w') as values_file:
-            yaml.safe_dump(values, values_file)
+            yaml.dump(values, values_file)
         manifests = render_helm_chart(helm_path)
         config = find_manifest(manifests, 'ConfigMap', 'mysubdomain-gk')
         deployment = find_manifest(manifests, 'Deployment', 'mysubdomain-gk')
         return (
-            yaml.safe_load(config['data']['proxy.yml']),
+            yaml.load(config['data']['proxy.yml']),
             deployment['spec']['template']['metadata']['annotations']['checksum/config'],
         )
 
@@ -1057,7 +1057,7 @@ def test_network_policy_defaults_from_value_template(tmp_path):
     )
 
     chart_path = out_folder / HELM_CHART_PATH / 'Chart.yaml'
-    chart = yaml.safe_load(open(chart_path, 'r'))
+    chart = yaml.load(open(chart_path, 'r'))
     assert chart['name'] == 'custom-chart'
     assert chart['version'] == '9.8.7'
     assert chart['appVersion'] == '4.5.6'
@@ -1129,7 +1129,7 @@ def render_with_secrets(tmp_path, name, secrets, secretmanagers=None, app='myapp
     shutil.rmtree(helm_path / 'charts', ignore_errors=True)
     values_path = helm_path / 'values.yaml'
     with open(values_path) as values_file:
-        values = yaml.safe_load(values_file)
+        values = yaml.load(values_file)
     values['apps'][app]['harness']['secrets'] = secrets
     # the test applications are not deployed by default, but we need the deployment to
     # check how the secrets are mounted
@@ -1139,7 +1139,7 @@ def render_with_secrets(tmp_path, name, secrets, secretmanagers=None, app='myapp
     if patch:
         patch(values)
     with open(values_path, 'w') as values_file:
-        yaml.safe_dump(values, values_file)
+        yaml.dump(values, values_file)
 
     return render_helm_chart(helm_path)
 
@@ -1351,7 +1351,7 @@ def test_secrets_definitions_survive_the_values_generation(tmp_path):
     shutil.rmtree(helm_path / 'charts', ignore_errors=True)
     values_path = helm_path / 'values.yaml'
     with open(values_path) as values_file:
-        values = yaml.safe_load(values_file)
+        values = yaml.load(values_file)
     secrets = values['apps']['myapp']['harness']['secrets']
     assert 'manager' in secrets['unmanagedSecret'], "the explicitly null manager must be kept"
     assert secrets['unmanagedSecret']['manager'] is None
@@ -1363,7 +1363,7 @@ def test_secrets_definitions_survive_the_values_generation(tmp_path):
 
     values['apps']['myapp']['harness']['deployment']['auto'] = True
     with open(values_path, 'w') as values_file:
-        yaml.safe_dump(values, values_file)
+        yaml.dump(values, values_file)
 
     manifests = render_helm_chart(helm_path)
     secret = find_manifest(manifests, 'Secret', 'myapp')


### PR DESCRIPTION
Closes [CH-291](https://metacell.atlassian.net/browse/CH-291)

# Implemented solution

ruamel.yaml is used everywhere now and configured, instead of base yaml and oyaml.

# How to test this PR

Run `harness-deployment`. It should work and the file should be formatted like

```yaml
a:
  b: b
  c: c
```
not 
```yaml
a: { b: b,  c: c }
```
# Sanity checks:
- [ ] The pull request is explicitly linked to the relevant issue(s)
- [ ] The issue is well described: clearly states the problem and the general proposed solution(s)
- [ ] In this PR it is explicitly stated how to test the current change
- [ ] The issue seta the scope and the type of issue (bug, story, task, etc.)
- [ ] The relevant components are indicated in the issue (if any)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one Sprint
- [ ] All the linked issues are in the Review state
- [ ] All the linked issues are assigned

# Breaking changes (select one):
- [ ] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change` and the migration procedure is well described [above](#implemented-solution)

# Possible deployment updates issues (select one):
- [ ] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif


[CH-291]: https://metacell.atlassian.net/browse/CH-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ